### PR TITLE
Adds the v201702 API

### DIFF
--- a/v201702/LICENSE
+++ b/v201702/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2015 Edward Middleton
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[Except as contained in this notice, the name of Edward Middleton
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+from Edward Middleton.]

--- a/v201702/ad_group.go
+++ b/v201702/ad_group.go
@@ -1,0 +1,287 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type AdGroupService struct {
+	Auth
+}
+
+func NewAdGroupService(auth *Auth) *AdGroupService {
+	return &AdGroupService{Auth: *auth}
+}
+
+type TargetSettingDetail struct {
+	CriterionTypeGroup string `xml:"criterionTypeGroup"`
+	TargetAll          bool   `xml:"targetAll"`
+}
+
+type AdSetting struct {
+	XMLName xml.Name `xml:"settings"`
+	Type    string   `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+
+	OptIn   *bool                 `xml:"optIn"`
+	Details []TargetSettingDetail `xml:"details"`
+}
+
+type AdGroup struct {
+	Id                           int64                          `xml:"id,omitempty"`
+	CampaignId                   int64                          `xml:"campaignId,omitempty"`
+	CampaignName                 string                         `xml:"campaignName,omitempty"`
+	Name                         string                         `xml:"name,omitempty"`
+	Status                       string                         `xml:"status,omitempty"`
+	Settings                     []AdSetting                    `xml:"settings,omitempty"`
+	BiddingStrategyConfiguration []BiddingStrategyConfiguration `xml:"biddingStrategyConfiguration"`
+	ContentBidCriterionTypeGroup *string                        `xml:"contentBidCriterionTypeGroup"`
+	UrlCustomParameters          *CustomParameters              `xml:"urlCustomParameters"`
+}
+
+type AdGroupOperations map[string][]AdGroup
+
+type AdGroupLabel struct {
+	AdGroupId int64 `xml:"adGroupId"`
+	LabelId   int64 `xml:"labelId"`
+}
+
+type AdGroupLabelOperations map[string][]AdGroupLabel
+
+// Get returns an array of ad group's and the total number of ad group's matching
+// the selector.
+//
+// Example
+//
+//   ads, totalCount, err := adGroupService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "Id",
+//         "CampaignId",
+//         "CampaignName",
+//         "Name",
+//         "Status",
+//         "Settings",
+//         "Labels",
+//         "ContentBidCriterionTypeGroup",
+//         "TrackingUrlTemplate",
+//         "UrlCustomParameters",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"Id", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "Id", "CampaignId", "CampaignName", "Name", "Status", "Settings", "Labels"
+//   "ContentBidCriterionTypeGroup", "TrackingUrlTemplate", "UrlCustomParameters"
+//
+// filterable fields are
+//   "Id", "CampaignId", "CampaignName", "Name", "Status", "Labels"
+//   "ContentBidCriterionTypeGroup", "TrackingUrlTemplate"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#get
+//
+func (s *AdGroupService) Get(selector Selector) (adGroups []AdGroup, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adGroupServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+	getResp := struct {
+		Size     int64     `xml:"rval>totalNumEntries"`
+		AdGroups []AdGroup `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+	return getResp.AdGroups, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove ad group's, returning the
+// modified ad group's.
+//
+// Example
+//
+//  ads, err := adGroupService.Mutate(
+//    gads.AdGroupOperations{
+//      "ADD": {
+//        gads.AdGroup{
+//          Name:       "my ad group ",
+//          Status:     "PAUSED",
+//          CampaignId:  campaignId,
+//          BiddingStrategyConfiguration: []gads.BiddingStrategyConfiguration{
+//            gads.BiddingStrategyConfiguration{
+//              StrategyType: "MANUAL_CPC",
+//              Bids: []gads.Bid{
+//                gads.Bid{
+//                  Type:   "CpcBid",
+//                  Amount: 10000,
+//                },
+//              },
+//            },
+//          },
+//        },
+//      },
+//      "SET": {
+//        modifiedAdGroup,
+//      },
+//      "REMOVE": {
+//        adGroupNeedingRemoval,
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#mutate
+//
+func (s *AdGroupService) Mutate(adGroupOperations AdGroupOperations) (adGroups []AdGroup, err error) {
+	type adGroupOperation struct {
+		Action  string  `xml:"operator"`
+		AdGroup AdGroup `xml:"operand"`
+	}
+	operations := []adGroupOperation{}
+	for action, adGroups := range adGroupOperations {
+		for _, adGroup := range adGroups {
+			operations = append(operations,
+				adGroupOperation{
+					Action:  action,
+					AdGroup: adGroup,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(adGroupServiceUrl, "mutate", mutation)
+	if err != nil {
+		return adGroups, err
+	}
+	mutateResp := struct {
+		AdGroups []AdGroup `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroups, err
+	}
+
+	return mutateResp.AdGroups, err
+}
+
+// MutateLabel allows you to add and removes labels from ad groups.
+//
+// Example
+//
+//  adGroups, err := adGroupService.MutateLabel(
+//    gads.AdGroupLabelOperations{
+//      "ADD": {
+//        gads.AdGroupLabel{AdGroupId: 3200, LabelId: 5353},
+//        gads.AdGroupLabel{AdGroupId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.AdGroupLabel{AdGroupId: 3653, LabelId: 5653},
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#mutateLabel
+//
+func (s *AdGroupService) MutateLabel(adGroupLabelOperations AdGroupLabelOperations) (adGroupLabels []AdGroupLabel, err error) {
+	type adGroupLabelOperation struct {
+		Action       string       `xml:"operator"`
+		AdGroupLabel AdGroupLabel `xml:"operand"`
+	}
+	operations := []adGroupLabelOperation{}
+	for action, adGroupLabels := range adGroupLabelOperations {
+		for _, adGroupLabel := range adGroupLabels {
+			operations = append(operations,
+				adGroupLabelOperation{
+					Action:       action,
+					AdGroupLabel: adGroupLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(adGroupServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return adGroupLabels, err
+	}
+	mutateResp := struct {
+		AdGroupLabels []AdGroupLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupLabels, err
+	}
+
+	return mutateResp.AdGroupLabels, err
+}
+
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#query
+//
+func (s *AdGroupService) Query(query string) (adGroups []AdGroup, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		adGroupServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+
+	getResp := struct {
+		Size     int64     `xml:"rval>totalNumEntries"`
+		AdGroups []AdGroup `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+	return getResp.AdGroups, getResp.Size, err
+
+}

--- a/v201702/ad_group_ad.go
+++ b/v201702/ad_group_ad.go
@@ -1,0 +1,465 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type AdGroupAdService struct {
+	Auth
+}
+
+type AppUrl struct {
+	Url    string `xml:"url"`
+	OsType string `xml:"osType"` // "OS_TYPE_IOS", "OS_TYPE_ANDROID", "UNKNOWN"
+}
+
+type TextAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Headline             string            `xml:"headline"`
+	Description1         string            `xml:"description1"`
+	Description2         string            `xml:"description2"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type ExpandedTextAd struct {
+	AdGroupId            int64                  `xml:"-"`
+	Id                   int64                  `xml:"id,omitempty"`
+	FinalUrls            []string               `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string               `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate  string                 `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters      `xml:"urlCustomParameters,omitempty"`
+	Type                 string                 `xml:"type,omitempty"`
+	HeadlinePart1        string                 `xml:"headlinePart1"`
+	HeadlinePart2        string                 `xml:"headlinePart2"`
+	Description          string                 `xml:"description"`
+	Path1                string                 `xml:"path1"`
+	Path2                string                 `xml:"path2"`
+	ExperimentData       *AdGroupExperimentData `xml:"-"`
+	Status               string                 `xml:"-"`
+	ApprovalStatus       string                 `xml:"-"`
+	Trademarks           []string               `xml:"-"`
+	DisapprovalReasons   []string               `xml:"-"`
+	TrademarkDisapproved bool                   `xml:"-"`
+	Labels               []Label                `xml:"-"`
+	BaseCampaignId       *int64                 `xml:"-"`
+	BaseAdGroupId        *int64                 `xml:"-"`
+}
+
+type ResponsiveDisplayAd struct {
+	AdGroupId            int64                 `xml:"-"`
+	Id                   int64                 `xml:"id,omitempty"`
+	FinalUrls            []string              `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string              `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate  string                `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters     `xml:"urlCustomParameters,omitempty"`
+	Type                 string                `xml:"type,omitempty"`
+	MarketingImage       Media                 `xml:"marketingImage"`
+	LogoImage            Media                 `xml:"logoImage"`
+	ShortHeadline        string                `xml:"shortHeadline"`
+	LongHeadline         string                `xml:"longHeadline"`
+	Description          string                `xml:"description"`
+	BusinessName         string                `xml:"businessName"`
+	ExperimentData       AdGroupExperimentData `xml:"-"`
+	Status               string                `xml:"-"`
+	ApprovalStatus       string                `xml:"-"`
+	Trademarks           []string              `xml:"-"`
+	DisapprovalReasons   []string              `xml:"-"`
+	TrademarkDisapproved bool                  `xml:"-"`
+	Labels               []Label               `xml:"-"`
+	BaseCampaignId       int64                 `xml:"-"`
+	BaseAdGroupId        int64                 `xml:"-"`
+}
+
+type AdGroupExperimentData struct {
+	ExperimentId          int64  `xml:"experimentId"`
+	ExperimentDeltaStatus string `xml:"experimentDeltaStatus"`
+	ExperimentDataStatus  string `xml:"experimentDataStatus"`
+}
+
+type ImageAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Image                int64             `xml:"imageId"`
+	Name                 string            `xml:"name"`
+	AdToCopyImageFrom    int64             `xml:"adToCopyImageFrom"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type MobileAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Headline             string            `xml:"headline"`
+	Description          string            `xml:"description"`
+	MarkupLanguages      []string          `xml:"markupLanguages"`
+	MobileCarriers       []string          `xml:"mobileCarriers"`
+	BusinessName         string            `xml:"businessName"`
+	CountryCode          string            `xml:"countryCode"`
+	PhoneNumber          string            `xml:"phoneNumber"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type TemplateElementField struct {
+	Name       string `xml:"name"`
+	Type       string `xml:"type"`
+	FieldText  string `xml:"fieldText"`
+	FieldMedia string `xml:"fieldMedia"`
+}
+
+type TemplateElement struct {
+	UniqueName string                 `xml:"uniqueName"`
+	Fields     []TemplateElementField `xml:"fields"`
+}
+
+type TemplateAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	TemplateId           int64             `xml:"templateId"`
+	AdUnionId            int64             `xml:"adUnionId>id"`
+	TemplateElements     []TemplateElement `xml:"templateElements"`
+	Dimensions           []Dimensions      `xml:"dimensions"`
+	Name                 string            `xml:"name"`
+	Duration             int64             `xml:"duration"`
+	originAdId           *int64            `xml:"originAdId"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type DynamicSearchAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+}
+
+type ProductAd struct {
+	AdGroupId            int64    `xml:"-"`
+	Id                   int64    `xml:"id,omitempty"`
+	Type                 string   `xml:"type,omitempty"`
+	Status               string   `xml:"-"`
+	ApprovalStatus       string   `xml:"-"`
+	DisapprovalReasons   []string `xml:"-"`
+	TrademarkDisapproved bool     `xml:"-"`
+}
+
+type AdGroupAdOperations map[string]AdGroupAds
+
+func NewAdGroupAdService(auth *Auth) *AdGroupAdService {
+	return &AdGroupAdService{Auth: *auth}
+}
+
+func NewTextAd(adGroupId int64, url, displayUrl, headline, description1, description2, status string) TextAd {
+	return TextAd{
+		AdGroupId:    adGroupId,
+		Url:          url,
+		DisplayUrl:   displayUrl,
+		Headline:     headline,
+		Description1: description1,
+		Description2: description2,
+		Status:       status,
+	}
+}
+
+type AdGroupAdLabel struct {
+	AdGroupAdId int64 `xml:"adGroupAdId"`
+	LabelId     int64 `xml:"labelId"`
+}
+
+type AdGroupAdLabelOperations map[string][]AdGroupAdLabel
+
+type AdUrlUpgrade struct {
+	AdId                int64  `xml:"adId"`
+	FinalUrl            string `xml:"finalUrl"`
+	FinalMobileUrl      string `xml:"finalMobileUrl"`
+	TrackingUrlTemplate string `xml:"trackingUrlTemplate"`
+}
+
+// Get returns an array of ad's and the total number of ad's matching
+// the selector.
+//
+// Example
+//
+//   ads, totalCount, err := adGroupAdService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//         "Status",
+//         "AdGroupCreativeApprovalStatus",
+//         "AdGroupAdDisapprovalReasons",
+//         "AdGroupAdTrademarkDisapproved",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"AdGroupId", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "Id", "Url", "DisplayUrl", "CreativeFinalUrls", "CreativeFinalMobileUrls",
+//   "CreativeFinalAppUrls", "CreativeTrackingUrlTemplate", "CreativeUrlCustomParameters",
+//   "DevicePreference", "Status", "AdGroupCreativeApprovalStatus", "AdGroupAdDisapprovalReasons"
+//   "AdGroupAdTrademarkDisapproved", "Labels"
+//
+//   TextAd
+//     "Headline", "Description1", "Description2"
+//
+//   ImageAd
+//     "ImageCreativeName"
+//
+// filterable fields are
+//   "AdGroupId", "Id", "Url", "DisplayUrl", "CreativeFinalUrls", "CreativeFinalMobileUrls",
+//   "CreativeFinalAppUrls", "CreativeTrackingUrlTemplate", "CreativeUrlCustomParameters",
+//   "DevicePreference", "Status", "AdGroupCreativeApprovalStatus", "AdGroupAdDisapprovalReasons"
+//   "Labels"
+//
+//   TextAd specific fields
+//     "Headline", "Description1", "Description2"
+//
+//   ImageAd specific fields
+//     "ImageCreativeName"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#get
+//
+func (s AdGroupAdService) Get(selector Selector) (adGroupAds AdGroupAds, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adGroupAdServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroupAds, totalCount, err
+	}
+	getResp := struct {
+		Size       int64      `xml:"rval>totalNumEntries"`
+		AdGroupAds AdGroupAds `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupAds, totalCount, err
+	}
+	return getResp.AdGroupAds, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove ads, returning the
+// modified ads.
+//
+// Example
+//
+//  ads, err := adGroupAdService.Mutate(
+//    gads.AdGroupAdOperations{
+//      "ADD": {
+//        gads.NewTextAd(
+//          adGroup.Id,
+//          "https://classdo.com/en",
+//          "classdo.com",
+//          "test headline",
+//          "test line one",
+//          "test line two",
+//          "PAUSED",
+//        ),
+//      },
+//      "SET": {
+//        modifiedAd,
+//      },
+//      "REMOVE": {
+//        adNeedingRemoval,
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#mutate
+//
+func (s *AdGroupAdService) Mutate(adGroupAdOperations AdGroupAdOperations) (adGroupAds AdGroupAds, err error) {
+	type adGroupAdOperation struct {
+		Action    string     `xml:"operator"`
+		AdGroupAd AdGroupAds `xml:"operand"`
+	}
+	operations := []adGroupAdOperation{}
+	for action, adGroupAds := range adGroupAdOperations {
+		for _, adGroupAd := range adGroupAds {
+			operations = append(operations,
+				adGroupAdOperation{
+					Action:    action,
+					AdGroupAd: []interface{}{adGroupAd},
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupAdOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(adGroupAdServiceUrl, "mutate", mutation)
+	if err != nil {
+		return adGroupAds, err
+	}
+	mutateResp := struct {
+		AdGroupAds AdGroupAds `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupAds, err
+	}
+	return mutateResp.AdGroupAds, err
+}
+
+// MutateLabel allows you to add and removes labels from ads.
+//
+// Example
+//
+//  ads, err := adGroupAdService.MutateLabel(
+//    gads.AdGroupAdLabelOperations{
+//      "ADD": {
+//        gads.AdGroupAdLabel{AdGroupAdId: 3200, LabelId: 5353},
+//        gads.AdGroupAdLabel{AdGroupAdId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.AdGroupAdLabel{AdGroupAdId: 3653, LabelId: 5653},
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#mutateLabel
+//
+func (s *AdGroupAdService) MutateLabel(adGroupAdLabelOperations AdGroupAdLabelOperations) (adGroupAdLabels []AdGroupAdLabel, err error) {
+	type adGroupAdLabelOperation struct {
+		Action         string         `xml:"operator"`
+		AdGroupAdLabel AdGroupAdLabel `xml:"operand"`
+	}
+	operations := []adGroupAdLabelOperation{}
+	for action, adGroupAdLabels := range adGroupAdLabelOperations {
+		for _, adGroupAdLabel := range adGroupAdLabels {
+			operations = append(operations,
+				adGroupAdLabelOperation{
+					Action:         action,
+					AdGroupAdLabel: adGroupAdLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupAdLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(adGroupAdServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return adGroupAdLabels, err
+	}
+	mutateResp := struct {
+		AdGroupAdLabels []AdGroupAdLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupAdLabels, err
+	}
+
+	return mutateResp.AdGroupAdLabels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#query
+//
+func (s *AdGroupAdService) Query(query string) (adGroupAds AdGroupAds, totalCount int64, err error) {
+	return adGroupAds, totalCount, ERROR_NOT_YET_IMPLEMENTED
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#upgradeUrl
+//
+func (s *AdGroupAdService) UpgradeUrl(adUrlUpgrades []AdUrlUpgrade) (adGroupAds AdGroupAds, err error) {
+	return adGroupAds, ERROR_NOT_YET_IMPLEMENTED
+}

--- a/v201702/ad_group_ad_test.go
+++ b/v201702/ad_group_ad_test.go
@@ -1,0 +1,61 @@
+package v201702
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testAdGroupAdService(t *testing.T) (service *AdGroupAdService) {
+	return &AdGroupAdService{Auth: testAuthSetup(t)}
+}
+
+func TestAdGroupAd(t *testing.T) {
+	adGroup, cleanupAdGroup := testAdGroup(t)
+	defer cleanupAdGroup()
+
+	agas := testAdGroupAdService(t)
+	adGroupAds, err := agas.Mutate(
+		AdGroupAdOperations{
+			"ADD": {
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test headline "+rand_word(10), "test line one", "test line two", "PAUSED"),
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test   teStTo "+rand_word(10), "test line one", "test line two", "PAUSED"),
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test headline "+rand_word(10), "test line one", "test line two", "PAUSED"),
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test headline "+rand_word(10), "test line one", "test line two", "PAUSED"),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, err = agas.Mutate(AdGroupAdOperations{"REMOVE": adGroupAds})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	adGroupIdStr := fmt.Sprintf("%d", adGroup.Id)
+	_, _, err = agas.Get(
+		Selector{
+			Fields: []string{
+				"AdGroupId",
+				"Id",
+				"Status",
+				"AdGroupCreativeApprovalStatus",
+				"AdGroupAdDisapprovalReasons",
+				"AdGroupAdTrademarkDisapproved",
+			},
+			Predicates: []Predicate{
+				{"AdGroupId", "EQUALS", []string{adGroupIdStr}},
+			},
+			Ordering: []OrderBy{
+				{"AdGroupId", "ASCENDING"},
+				{"Id", "ASCENDING"},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/v201702/ad_group_ads.go
+++ b/v201702/ad_group_ads.go
@@ -1,0 +1,217 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type AdGroupAds []interface{}
+
+func (a1 AdGroupAds) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	a := a1[0]
+	e.EncodeToken(start)
+	switch a.(type) {
+	case TextAd:
+		ad := a.(TextAd)
+		e.EncodeElement(ad.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+		e.EncodeElement(ad, xml.StartElement{
+			xml.Name{"", "ad"},
+			[]xml.Attr{
+				xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "TextAd"},
+			},
+		})
+		e.EncodeElement(ad.Status, xml.StartElement{Name: xml.Name{"", "status"}})
+		e.EncodeElement(ad.Labels, xml.StartElement{Name: xml.Name{"", "labels"}})
+	case ExpandedTextAd:
+		ad := a.(ExpandedTextAd)
+		e.EncodeElement(ad.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+		e.EncodeElement(ad, xml.StartElement{
+			xml.Name{"", "ad"},
+			[]xml.Attr{
+				xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "ExpandedTextAd"},
+			},
+		})
+		e.EncodeElement(ad.Status, xml.StartElement{Name: xml.Name{"", "status"}})
+		e.EncodeElement(ad.Labels, xml.StartElement{Name: xml.Name{"", "labels"}})
+	case ImageAd:
+		return ERROR_NOT_YET_IMPLEMENTED
+	case TemplateAd:
+		return ERROR_NOT_YET_IMPLEMENTED
+	default:
+		return fmt.Errorf("unknown Ad type -> %#v", start)
+	}
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	typeName := xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"}
+	var adGroupId int64
+	var status, approvalStatus string
+	var disapprovalReasons []string
+	var trademarkDisapproved bool
+	var labels []Label
+	var experimentData *AdGroupExperimentData
+	var trademarks []string
+	var baseCampaignId *int64
+	var baseAdGroupId *int64
+	var ad interface{}
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "adGroupId":
+				err := dec.DecodeElement(&adGroupId, &start)
+				if err != nil {
+					return err
+				}
+			case "ad":
+				typeName, err := findAttr(start.Attr, typeName)
+				if err != nil {
+					return err
+				}
+				fmt.Println(typeName)
+				switch typeName {
+				case "TextAd":
+					a := TextAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "ExpandedTextAd":
+					a := ExpandedTextAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "ImageAd":
+					a := ImageAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "TemplateAd":
+					a := TemplateAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "DynamicSearchAd":
+					a := DynamicSearchAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+				case "ProductAd":
+					a := ProductAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("unknown AdGroupCriterion -> %#v", start)
+				}
+			case "experimentData":
+				err := dec.DecodeElement(&experimentData, &start)
+				if err != nil {
+					return err
+				}
+			case "status":
+				err := dec.DecodeElement(&status, &start)
+				if err != nil {
+					return err
+				}
+			case "approvalStatus":
+				err := dec.DecodeElement(&approvalStatus, &start)
+				if err != nil {
+					return err
+				}
+			case "trademarks":
+				err := dec.DecodeElement(&trademarks, &start)
+				if err != nil {
+					return err
+				}
+			case "disapprovalReasons":
+				err := dec.DecodeElement(&disapprovalReasons, &start)
+				if err != nil {
+					return err
+				}
+			case "trademarkDisapproved":
+				err := dec.DecodeElement(&trademarkDisapproved, &start)
+				if err != nil {
+					return err
+				}
+			case "labels":
+				err := dec.DecodeElement(&labels, &start)
+				if err != nil {
+					return err
+				}
+			case "baseCampaignId":
+				err := dec.DecodeElement(&baseCampaignId, &start)
+				if err != nil {
+					return err
+				}
+			case "baseAdGroupId":
+				err := dec.DecodeElement(&baseAdGroupId, &start)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unknown AdGroupAd field -> %#v", tag)
+			}
+
+		}
+	}
+	switch a := ad.(type) {
+	case TextAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case ExpandedTextAd:
+		a.ExperimentData = experimentData
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.Trademarks = trademarks
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		a.Labels = labels
+		a.BaseCampaignId = baseCampaignId
+		a.BaseAdGroupId = baseAdGroupId
+		*aga = append(*aga, a)
+	case ImageAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case TemplateAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case DynamicSearchAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case ProductAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	}
+	return nil
+}

--- a/v201702/ad_group_bid_modifier.go
+++ b/v201702/ad_group_bid_modifier.go
@@ -1,0 +1,24 @@
+package v201702
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type AdGroupBidModifierService struct {
+	Auth
+}
+
+func NewAdGroupBidModifierService(auth *Auth) *AdGroupBidModifierService {
+	return &AdGroupBidModifierService{Auth: *auth}
+}
+
+/*
+type AdGroupBidModifier struct {
+  CampaignId        int64     `xml:"campaignId"`
+  AdGroupId         int64     `xml:"adGroupId"`
+  Criterion         Criterion `xml:"criterion"`
+  BidModifier       float64   `xml:"bidModifier"`
+  BidModifierSource string    `xml:"bidModifierSource"`
+}
+*/

--- a/v201702/ad_group_criterion.go
+++ b/v201702/ad_group_criterion.go
@@ -1,0 +1,339 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type AdGroupCriterionService struct {
+	Auth
+}
+
+func NewAdGroupCriterionService(auth *Auth) *AdGroupCriterionService {
+	return &AdGroupCriterionService{Auth: *auth}
+}
+
+type QualityInfo struct {
+	QualityScore int64 `xml:"qualityScore,omitempty"`
+}
+
+type CpcAmount struct {
+	MicroAmount int64 `xml:"microAmount,omitempty"`
+}
+
+type Cpc struct {
+	Amount *CpcAmount `xml:"amount,omitempty"`
+}
+
+type AdGroupCriterions []interface{}
+
+type AdGroupCriterionLabel struct {
+	AdGroupCriterionId int64 `xml:"adGroupCriterionId"`
+	LabelId            int64 `xml:"labelId"`
+}
+
+type AdGroupCriterionLabelOperations map[string][]AdGroupCriterionLabel
+
+func (agcs *AdGroupCriterions) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	adGroupCriterionType, err := findAttr(start.Attr, xml.Name{
+		Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return err
+	}
+	switch adGroupCriterionType {
+	case "BiddableAdGroupCriterion":
+		bagc := BiddableAdGroupCriterion{}
+		err := dec.DecodeElement(&bagc, &start)
+		if err != nil {
+			return err
+		}
+		*agcs = append(*agcs, bagc)
+	case "NegativeAdGroupCriterion":
+		nagc := NegativeAdGroupCriterion{}
+		err := dec.DecodeElement(&nagc, &start)
+		if err != nil {
+			return err
+		}
+		*agcs = append(*agcs, nagc)
+	default:
+		return fmt.Errorf("unknown AdGroupCriterion -> %#v", adGroupCriterionType)
+	}
+	return nil
+}
+
+type AdGroupCriterionOperations map[string]AdGroupCriterions
+
+// Get returns an array of AdGroupCriterion's and the total number of AdGroupCriterion's matching
+// the selector.
+//
+// Example
+//
+//   adGroupCriterions, totalCount, err := adGroupCriterionService.Get(
+//     Selector{
+//       Fields: []string{"Id","KeywordText","KeywordMatchType"},
+//       Predicates: []Predicate{
+//         {"AdGroupId", "EQUALS", []string{"432434"}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "CriterionUse", "Id", "CriteriaType", "Labels"
+//
+//   AgeRange
+//     "AgeRangeType",
+//
+//   AppPaymentModel
+//     "AppPaymentModelType",
+//
+//   CriterionUserInterest
+//     "UserInterestId", "UserInterestName",
+//
+//   CriterionUserList
+//     "UserListId", "UserListName", "UserListMembershipStatus"
+//
+//   Gender
+//     "GenderType"
+//
+//   Keyword
+//     "KeywordText", "KeywordMatchType"
+//
+//   MobileAppCategory
+//     "MobileAppCategoryId"
+//
+//   MobileApplication
+//     "DisplayName"
+//
+//   Placement
+//     "PlacementUrl"
+//
+//   Product
+//     "Text"
+//
+//   ProductPartition
+//     "PartitionType", "ParentCriterionId", "CaseValue"
+//
+//   Vertical
+//     "VerticalId", "VerticalParentId", "Path"
+//
+//   Webpage
+//     "Parameter", "CriteriaCoverage", "CriteriaSamples"
+//
+// filterable fields are
+//
+//   "AdGroupId", "CriterionUse", "Id", "CriteriaType", "Labels"
+//
+//   CriterionUserList
+//     "UserListMembershipStatus"
+//
+//   Keyword
+//     "KeywordText", "KeywordMatchType"
+//
+//   MobileApplication
+//     "DisplayName"
+//
+//   Placement
+//     "PlacementUrl"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#get
+//
+func (s AdGroupCriterionService) Get(selector Selector) (adGroupCriterions AdGroupCriterions, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adGroupCriterionServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+	getResp := struct {
+		Size              int64             `xml:"rval>totalNumEntries"`
+		AdGroupCriterions AdGroupCriterions `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+	return getResp.AdGroupCriterions, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove ad group criterion, returning the
+// modified ad group criterion.
+//
+// Example
+//
+//  ads, err := adGroupService.Mutate(
+//    gads.AdGroupCriterionOperations{
+//      "ADD": {
+//        BiddableAdGroupCriterion{
+//          AdGroupId:  adGroupId,
+//          Criterion:  gads.KeywordCriterion{Text: "test1", MatchType: "EXACT"},
+//          UserStatus: "PAUSED",
+//        },
+//        NegativeAdGroupCriterion{
+//          AdGroupId: adGroupId,
+//          Criterion: gads.KeywordCriterion{Text: "test4", MatchType: "BROAD"},
+//        },
+//      },
+//      "SET": {
+//        modifiedAdGroupCriterion,
+//      },
+//      "REMOVE": {
+//        adGroupCriterionNeedingRemoval,
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#mutate
+//
+func (s *AdGroupCriterionService) Mutate(adGroupCriterionOperations AdGroupCriterionOperations) (adGroupCriterions AdGroupCriterions, err error) {
+	type adGroupCriterionOperation struct {
+		Action           string      `xml:"operator"`
+		AdGroupCriterion interface{} `xml:"operand"`
+	}
+	operations := []adGroupCriterionOperation{}
+	for action, adGroupCriterions := range adGroupCriterionOperations {
+		for _, adGroupCriterion := range adGroupCriterions {
+			operations = append(operations,
+				adGroupCriterionOperation{
+					Action:           action,
+					AdGroupCriterion: adGroupCriterion,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupCriterionOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(adGroupCriterionServiceUrl, "mutate", mutation)
+	if err != nil {
+		return adGroupCriterions, err
+	}
+	mutateResp := struct {
+		AdGroupCriterions AdGroupCriterions `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupCriterions, err
+	}
+
+	return mutateResp.AdGroupCriterions, err
+}
+
+// MutateLabel allows you to add and removes labels from ad groups.
+//
+// Example
+//
+//  adGroupCriterions, err := adGroupCriterionService.MutateLabel(
+//    gads.AdGroupCriterionLabelOperations{
+//      "ADD": {
+//        gads.AdGroupCriterionLabel{AdGroupCriterionId: 3200, LabelId: 5353},
+//        gads.AdGroupCriterionLabel{AdGroupCriterionId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.AdGroupCriterionLabel{AdGroupCriterionId: 3653, LabelId: 5653},
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#mutateLabel
+//
+func (s *AdGroupCriterionService) MutateLabel(adGroupCriterionLabelOperations AdGroupCriterionLabelOperations) (adGroupCriterionLabels []AdGroupCriterionLabel, err error) {
+	type adGroupCriterionLabelOperation struct {
+		Action                string                `xml:"operator"`
+		AdGroupCriterionLabel AdGroupCriterionLabel `xml:"operand"`
+	}
+	operations := []adGroupCriterionLabelOperation{}
+	for action, adGroupCriterionLabels := range adGroupCriterionLabelOperations {
+		for _, adGroupCriterionLabel := range adGroupCriterionLabels {
+			operations = append(operations,
+				adGroupCriterionLabelOperation{
+					Action:                action,
+					AdGroupCriterionLabel: adGroupCriterionLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupCriterionLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(adGroupCriterionServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return adGroupCriterionLabels, err
+	}
+	mutateResp := struct {
+		AdGroupCriterionLabels []AdGroupCriterionLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupCriterionLabels, err
+	}
+
+	return mutateResp.AdGroupCriterionLabels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#query
+//
+func (s *AdGroupCriterionService) Query(query string) (adGroupCriterions AdGroupCriterions, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		adGroupCriterionServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+
+	getResp := struct {
+		Size              int64             `xml:"rval>totalNumEntries"`
+		AdGroupCriterions AdGroupCriterions `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+	return getResp.AdGroupCriterions, getResp.Size, err
+
+}

--- a/v201702/ad_group_criterion_test.go
+++ b/v201702/ad_group_criterion_test.go
@@ -1,0 +1,96 @@
+package v201702
+
+import (
+	"testing"
+	//	"encoding/xml"
+)
+
+func testAdGroupCriterionService(t *testing.T) (service *AdGroupCriterionService) {
+	return &AdGroupCriterionService{Auth: testAuthSetup(t)}
+}
+
+func TestAdGroupCriterion(t *testing.T) {
+	adGroup, cleanupAdGroup := testAdGroup(nil)
+	defer cleanupAdGroup()
+
+	agcs := testAdGroupCriterionService(t)
+	adGroupCriterions, err := agcs.Mutate(
+		AdGroupCriterionOperations{
+			"ADD": {
+				/*
+									NegativeAdGroupCriterion{
+					          AdGroupId: adGroup.Id,
+					          Criterion: AgeRangeCriterion{AgeRangeType:"AGE_RANGE_25_34"},
+					        },
+									NegativeAdGroupCriterion{
+					          AdGroupId: adGroup.Id,
+					          Criterion: GenderCriterion{},
+					        },
+									NewBiddableAdGroupCriterion{
+					          AdGroupId: adGroup.Id,
+					          Criterion: MobileAppCategoryCriterion{
+					            60000,"My Google Play Android Apps"
+					          }
+					        },
+				*/
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  KeywordCriterion{Text: "test1", MatchType: "EXACT"},
+					UserStatus: "PAUSED",
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  KeywordCriterion{Text: "test2", MatchType: "PHRASE"},
+					UserStatus: "PAUSED",
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  KeywordCriterion{Text: "test3", MatchType: "BROAD"},
+					UserStatus: "PAUSED",
+				},
+				NegativeAdGroupCriterion{
+					AdGroupId: adGroup.Id,
+					Criterion: KeywordCriterion{Text: "test4", MatchType: "BROAD"},
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  PlacementCriterion{Url: "https://classdo.com"},
+					UserStatus: "PAUSED",
+				},
+				// NewBiddableAdGroupCriterion(adGroup.Id, NewUserInterestCriterion()),
+				// NewBiddableAdGroupCriterion(adGroup.Id, NewUserListCriterion()),
+				// NewBiddableAdGroupCriterion(adGroup.Id, NewVerticalCriterion(0, 0, []string{"Pets & Anamals","Pets","Dogs"})),
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroup.Id,
+					Criterion: WebpageCriterion{
+						Parameter: WebpageParameter{
+							CriterionName: "test criterion",
+							Conditions: []WebpageCondition{
+								WebpageCondition{
+									Operand:  "URL",
+									Argument: "example.com",
+								},
+							},
+						},
+					},
+					UserStatus: "PAUSED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%#v", adGroupCriterions)
+
+	defer func() {
+		_, err = agcs.Mutate(AdGroupCriterionOperations{"REMOVE": adGroupCriterions})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	/*
+	   reqBody, err := xml.MarshalIndent(adGroupCriterions,"  ", "  ")
+	   t.Fatalf("%s\n",reqBody)
+	*/
+}

--- a/v201702/ad_group_extension.go
+++ b/v201702/ad_group_extension.go
@@ -1,0 +1,96 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService#query
+type AdGroupExtensionSettingService struct {
+	Auth
+}
+
+func NewAdGroupExtensionSettingService(auth *Auth) *AdGroupExtensionSettingService {
+	return &AdGroupExtensionSettingService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.AdGroupExtensionSetting
+// An AdGroupExtensionSetting is used to add or modify extensions being served for the specified ad group.
+type AdGroupExtensionSetting struct {
+	AdGroupId        int64            `xml:"https://adwords.google.com/api/adwords/cm/v201702 adGroupId,omitempty"`
+	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201702 extensionType,omitempty"`
+	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201702 extensionSetting,omitempty"`
+}
+
+type AdGroupExtensionSettingOperations map[string][]AdGroupExtensionSetting
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService#query
+func (s *AdGroupExtensionSettingService) Query(query string) (settings []AdGroupExtensionSetting, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		adGroupExtensionSettingServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	getResp := struct {
+		Size     int64                     `xml:"rval>totalNumEntries"`
+		Settings []AdGroupExtensionSetting `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return
+	}
+	return getResp.Settings, getResp.Size, err
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService#mutate
+func (s *AdGroupExtensionSettingService) Mutate(settingsOperations AdGroupExtensionSettingOperations) (settings []AdGroupExtensionSetting, err error) {
+	type settingOperations struct {
+		Action  string                  `xml:"operator"`
+		Setting AdGroupExtensionSetting `xml:"operand"`
+	}
+	operations := []settingOperations{}
+	for action, settings := range settingsOperations {
+		for _, setting := range settings {
+			operations = append(operations,
+				settingOperations{
+					Action:  action,
+					Setting: setting,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []settingOperations `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+
+	respBody, err := s.Auth.request(adGroupExtensionSettingServiceUrl, "mutate", mutation)
+	if err != nil {
+		return settings, err
+	}
+	mutateResp := struct {
+		Settings []AdGroupExtensionSetting `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal(respBody, &mutateResp)
+	if err != nil {
+		return settings, err
+	}
+
+	return mutateResp.Settings, err
+}

--- a/v201702/ad_group_feed.go
+++ b/v201702/ad_group_feed.go
@@ -1,0 +1,50 @@
+package v201702
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type AdGroupFeedService struct {
+	Auth
+}
+
+func NewAdGroupFeedService(auth *Auth) *AdGroupFeedService {
+	return &AdGroupFeedService{Auth: *auth}
+}
+
+type AdGroupFeedOperations struct {
+}
+
+type AdGroupFeed struct {
+}
+
+// Get is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#get
+//
+func (s AdGroupFeedService) Get(selector Selector) (adGroupFeeds []AdGroupFeed, err error) {
+	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
+}
+
+// Mutate is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#mutate
+//
+func (s *AdGroupFeedService) Mutate(adGroupFeedOperations AdGroupFeedOperations) (adGroupFeeds []AdGroupFeed, err error) {
+	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#query
+//
+func (s *AdGroupFeedService) Query(query string) (adGroupFeeds []AdGroupFeed, err error) {
+	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
+}

--- a/v201702/ad_group_test.go
+++ b/v201702/ad_group_test.go
@@ -1,0 +1,79 @@
+package v201702
+
+import (
+	"testing"
+	//  "encoding/xml"
+)
+
+func testAdGroupService(t *testing.T) (service *AdGroupService) {
+	return &AdGroupService{Auth: testAuthSetup(t)}
+}
+
+func testAdGroup(t *testing.T) (AdGroup, func()) {
+	campaign, cleanupCampaign := testCampaign(t)
+	ags := testAdGroupService(t)
+	adGroups, err := ags.Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       "test ad group " + rand_str(10),
+					Status:     "PAUSED",
+					CampaignId: campaign.Id,
+					BiddingStrategyConfiguration: []BiddingStrategyConfiguration{
+						BiddingStrategyConfiguration{
+							StrategyType: "MANUAL_CPC",
+							Bids: []Bid{
+								Bid{
+									Type:   "CpcBid",
+									Amount: 10000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAdGroup := func() {
+		adGroups[0].Status = "REMOVED"
+		_, err = ags.Mutate(AdGroupOperations{"SET": adGroups})
+		if err != nil {
+			t.Error(err)
+		}
+		cleanupCampaign()
+	}
+	return adGroups[0], cleanupAdGroup
+}
+
+func TestAdGroup(t *testing.T) {
+	campaign, cleanupCampaign := testCampaign(t)
+	defer cleanupCampaign()
+
+	ags := testAdGroupService(t)
+	adGroups, err := ags.Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       "test ad group " + rand_str(10),
+					Status:     "PAUSED",
+					CampaignId: campaign.Id,
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		adGroups[0].Status = "REMOVED"
+		_, err = ags.Mutate(AdGroupOperations{"SET": adGroups})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+}

--- a/v201702/ad_param.go
+++ b/v201702/ad_param.go
@@ -1,0 +1,27 @@
+package v201702
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type AdParamService struct {
+	Auth
+}
+
+type AdParam struct {
+}
+
+func NewAdParamService(auth *Auth) *AdParamService {
+	return &AdParamService{Auth: *auth}
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdParamService#get
+//
+func (s AdParamService) Get(selector Selector) (adParams []AdParam, err error) {
+	return adParams, ERROR_NOT_YET_IMPLEMENTED
+}

--- a/v201702/adwords_user_list.go
+++ b/v201702/adwords_user_list.go
@@ -1,0 +1,382 @@
+package v201702
+
+import (
+	sha256 "crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"io"
+)
+
+type AdwordsUserListService struct {
+	Auth
+}
+
+func NewAdwordsUserListService(auth *Auth) *AdwordsUserListService {
+	return &AdwordsUserListService{Auth: *auth}
+}
+
+type UserListLogicalRule struct {
+	Operator     string     `xml:"operator"` // "ALL", "ANY", "NONE", "UNKNOWN"
+	RuleOperands []UserList `xml:"ruleOperands"`
+}
+
+type UserListConversionType struct {
+	Id       *int64
+	Name     string
+	Category *string `xml:"category"` // "BOOMERANG_EVENT", "OTHER"
+}
+
+// Rule structs
+type DateRuleItem struct {
+	Key   string `xml:"key>name"`
+	Op    string `xml:"op"` // "UNKNOWN", "EQUALS", "NOT_EQUAL", "BEFORE", "AFTER"
+	Value string `xml:"string"`
+}
+
+type NumberRuleItem struct {
+	Key   string `xml:"key>name"`
+	Op    string `xml:"op"` // "UNKNOWN", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "EQUALS", "NOT_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL"
+	Value int64  `xml:"value"`
+}
+
+type StringRuleItem struct {
+	Key   string `xml:"key>name"`
+	Op    string `xml:"op"` // "UNKNOWN", "CONTAINS", "EQUALS", "STARTS_WITH", "ENDS_WITH", "NOT_EQUAL", "NOT_CONTAIN", "NOT_START_WITH", "NOT_END_WITH"
+	Value string `xml:"string"`
+}
+
+type RuleItemGroup struct {
+	Items []interface{} `xml:"items"`
+}
+
+type Rule struct {
+	Groups []RuleItemGroup `xml:"groups"`
+}
+
+type UserListOperations struct {
+	XMLName    xml.Name
+	Operations []Operation `xml:"operations"`
+}
+
+type MutateMembersOperations struct {
+	XMLName    xml.Name
+	Operations []Operation `xml:"operations"`
+}
+
+type MutateMembersOperand struct {
+	UserListId int64    `xml:"userListId"`
+	DataType   string   `xml:"dataType"`
+	RemoveAll  *bool    `xml:"removeAll"`
+	Members    []string `xml:"members"`
+}
+
+type UserList struct {
+	Id                    int64   `xml:"id,omitempty"`
+	Readonly              *bool   `xml:"isReadOnly"`
+	Name                  string  `xml:"name"`
+	Description           string  `xml:"description"`
+	Status                string  `xml:"status"` // membership status "OPEN", "CLOSED"
+	IntegrationCode       string  `xml:"integrationCode"`
+	AccessReason          string  `xml:"accessReason"`          // account access resson "OWNER", "SHARED", "LICENSED", "SUBSCRIBED"
+	AccountUserListStatus string  `xml:"accountUserListStatus"` // if share is still active "ACTIVE", "INACTIVE"
+	MembershipLifeSpan    int64   `xml:"membershipLifeSpan"`    // number of days cookie stays on list
+	Size                  *int64  `xml:"size,omitempty"`
+	SizeRange             *string `xml:"sizeRange,omitempty"`          // size range "LESS_THEN_FIVE_HUNDRED","LESS_THAN_ONE_THOUSAND", "ONE_THOUSAND_TO_TEN_THOUSAND","TEN_THOUSAND_TO_FIFTY_THOUSAND","FIFTY_THOUSAND_TO_ONE_HUNDRED_THOUSAND","ONE_HUNDRED_THOUSAND_TO_THREE_HUNDRED_THOUSAND","THREE_HUNDRED_THOUSAND_TO_FIVE_HUNDRED_THOUSAND","FIVE_HUNDRED_THOUSAND_TO_ONE_MILLION","ONE_MILLION_TO_TWO_MILLION","TWO_MILLION_TO_THREE_MILLION","THREE_MILLION_TO_FIVE_MILLION","FIVE_MILLION_TO_TEN_MILLION","TEN_MILLION_TO_TWENTY_MILLION","TWENTY_MILLION_TO_THIRTY_MILLION","THIRTY_MILLION_TO_FIFTY_MILLION","OVER_FIFTY_MILLION"
+	SizeForSearch         *int64  `xml:"sizeForSearch,omitempty"`      // estimated number of google.com users in this group
+	SizeRangeForSearch    *string `xml:"sizeRangeForSearch,omitempty"` // same values as size range but for search
+	ListType              *string `xml:"sizeType,omitempty"`           // one of "UNKNOWN", "REMARKETING", "LOGICAL", "EXTERNAL_REMARKETING", "RULE_BASED", "SIMILAR"
+
+	// LogicalUserList
+	LogicalRules *[]UserListLogicalRule `xml:"rules,omitempty"`
+
+	// BasicUserList
+	ConversionTypes *[]UserListConversionType `xml:"conversionTypes"`
+
+	// RuleUserList
+	Rule      *Rule   `xml:"rule,omitempty"`
+	StartDate *string `xml:"startDate,omitempty"`
+	EndDate   *string `xml:"endDate,omitempty"`
+
+	// SimilarUserList
+	SeedUserListId          *int64  `xml:"seedUserListId,omitempty"`
+	SeedUserListName        *string `xml:"seedUserListName,omitempty"`
+	SeedUserListDescription *string `xml:"seedUserListDescription,omitempty"`
+	SeedUserListStatus      *string `xml:"seedUserListStatus,omitempty"`
+	SeedListSize            *int64  `xml:"seedListSize,omitempty"`
+
+	// CrmBasedUserList
+	OptOutLink *string `xml:"optOutLink,omitempty"`
+
+	// Keep track of xsi:type for mutate and mutateMembers
+	Xsi_type string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+}
+
+// DoubleClick platform user list mapped to AdWords
+//func NewExternalRemarketingUserList() (adwordsUserList UserList) {
+//}
+
+//
+func NewLogicalUserList(name, description, status, integrationCode string, membershipLifeSpan int64, logicalRules []UserListLogicalRule) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		LogicalRules:       &logicalRules,
+		Xsi_type:           "LogicalUserList",
+	}
+}
+
+func NewBasicUserList(name, description, status, integrationCode string, membershipLifeSpan int64, conversionTypes []UserListConversionType) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		ConversionTypes:    &conversionTypes,
+		Xsi_type:           "BasicUserList",
+	}
+}
+
+func NewDateSpecificRuleUserList(name, description, status, integrationCode string, membershipLifeSpan int64, rule Rule, startDate, endDate string) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		Rule:               &rule,
+		StartDate:          &startDate,
+		EndDate:            &endDate,
+		Xsi_type:           "DateSpecificRuleUserList",
+	}
+}
+
+func NewExpressionRuleUserList(name, description, status, integrationCode string, membershipLifeSpan int64, rule Rule) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		Rule:               &rule,
+		Xsi_type:           "ExpressionRuleUserList",
+	}
+}
+
+func NewSimilarUserList(name, description, status, integrationCode string, membershipLifeSpan int64) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		Xsi_type:           "SimilarUserList",
+	}
+}
+
+func NewCrmBasedUserList(name, description string, membershipLifeSpan int64, optOutLink string) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		MembershipLifeSpan: membershipLifeSpan,
+		OptOutLink:         &optOutLink,
+		Xsi_type:           "CrmBasedUserList",
+	}
+}
+
+func NewMutateMembersOperand() *MutateMembersOperand {
+	return &MutateMembersOperand{DataType: "EMAIL_SHA256"}
+}
+
+// Get returns an array of adwords user lists and the total number of adwords user lists matching
+// the selector.
+//
+// Example
+//
+//   ads, totalCount, err := adwordsUserListService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "Id",
+//         "Name",
+//         "Status",
+//         "Labels",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"Id", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "Id", "IsReadOnly", "Name", "Description", "Status", "IntegrationCode", "AccessReason",
+//   "AccountUserListStatus", "MembershipLifeSpan", "Size", "SizeRange", "SizeForSearch",
+//   "SizeRangeForSearch", "ListType"
+//
+//   BasicUserList
+//     "ConversionType"
+//
+//   LogicalUserList
+//     "Rules"
+//
+//   SimilarUserList
+//     "SeedUserListId", "SeedUserListName", "SeedUserListDescription", "SeedUserListStatus",
+//     "SeedListSize"
+//
+// filterable fields are
+//   "Id", "Name", "Status", "IntegrationCode", "AccessReason", "AccountUserListStatus",
+//   "MembershipLifeSpan", "Size", "SizeForSearch", "ListType"
+//
+//   SimilarUserList
+//     "SeedUserListId", "SeedListSize"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/AdwordsUserListService#get
+//
+func (s AdwordsUserListService) Get(selector Selector) (userLists []UserList, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adwordsUserListServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return userLists, err
+	}
+	getResp := struct {
+		Size      int64      `xml:"rval>totalNumEntries"`
+		UserLists []UserList `xml:"rval>entries"`
+	}{}
+	fmt.Printf("%s\n", respBody)
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return userLists, err
+	}
+	return getResp.UserLists, err
+}
+
+// Mutate adds/sets a collection of user lists. Returns a list of User Lists
+//
+// Example
+// 	auls := gads.NewAdwordsUserListService(&config.Auth)
+//
+//	crmList := gads.NewCrmBasedUserList("Test List", "Just a list to test with", 0, "http://mytest.com/optout")
+//
+//	ops := gads.UserListOperations{
+//		Operations: []gads.Operation{
+//			gads.Operation{
+//				Operator: "ADD",
+//				Operand: crmList,
+//			},
+//		},
+//	}
+//
+//	resp, err := auls.Mutate(ops)
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/AdwordsUserListService#mutate
+//
+func (s *AdwordsUserListService) Mutate(userListOperations UserListOperations) (adwordsUserLists []UserList, err error) {
+
+	userListOperations.XMLName = xml.Name{
+		Space: baseRemarketingUrl,
+		Local: "mutate",
+	}
+
+	respBody, err := s.Auth.request(adwordsUserListServiceUrl, "mutate", userListOperations)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+	mutateResp := struct {
+		AdwordsUserLists []UserList `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+
+	return mutateResp.AdwordsUserLists, err
+}
+
+// Mutate adds/removes members/emails to specified user list.
+// Note: Only 1 operation per userListId
+//
+// Example
+// 	mmo := gads.NewMutateMembersOperand()
+// 	mmo.UserListId = resp[0].Id
+
+// 	var members []string
+// 	members = append(members,"brian@test.com")
+// 	members = append(members,"test@test.com")
+
+// 	mmo.Members = members
+
+// 	mutateMembersOperations := gads.MutateMembersOperations{
+// 		Operations: []gads.Operation{
+// 			gads.Operation{
+// 				Operator: "ADD",
+// 				Operand: mmo,
+// 			},
+// 		},
+// 	}
+//
+// 	auls.MutateMembers(mutateMembersOperations)
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/AdwordsUserListService#mutateMembers
+//
+func (s *AdwordsUserListService) MutateMembers(mutateMembersOperations MutateMembersOperations) (adwordsUserLists []UserList, err error) {
+	mutateMembersOperations.XMLName = xml.Name{
+		Space: baseRemarketingUrl,
+		Local: "mutateMembers",
+	}
+
+	respBody, err := s.Auth.request(adwordsUserListServiceUrl, "mutateMembers", mutateMembersOperations)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+	mutateResp := struct {
+		AdwordsUserLists []UserList `xml:"rval>userLists"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+
+	return mutateResp.AdwordsUserLists, err
+}
+
+func (mmo MutateMembersOperand) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+
+	mmo.encodeEmails()
+
+	e.EncodeToken(start)
+	e.EncodeElement(&mmo.UserListId, xml.StartElement{Name: xml.Name{baseRemarketingUrl, "userListId"}})
+	e.EncodeElement(&mmo.DataType, xml.StartElement{Name: xml.Name{baseRemarketingUrl, "dataType"}})
+	e.EncodeElement(&mmo.Members, xml.StartElement{Name: xml.Name{baseRemarketingUrl, "members"}})
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (mmo *MutateMembersOperand) encodeEmails() {
+
+	for key, value := range mmo.Members {
+		h256 := sha256.New()
+		io.WriteString(h256, value)
+		mmo.Members[key] = fmt.Sprintf("%x", h256.Sum(nil))
+	}
+}

--- a/v201702/base.go
+++ b/v201702/base.go
@@ -1,0 +1,280 @@
+package v201702
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+const (
+	version               = "v201702"
+	rootUrl               = "https://adwords.google.com/api/adwords/cm/"
+	baseUrl               = "https://adwords.google.com/api/adwords/cm/" + version
+	rootMcmUrl            = "https://adwords.google.com/api/adwords/mcm/"
+	baseMcmUrl            = "https://adwords.google.com/api/adwords/mcm/" + version
+	rootRemarketingUrl    = "https://adwords.google.com/api/adwords/rm/"
+	baseRemarketingUrl    = "https://adwords.google.com/api/adwords/rm/" + version
+	rootReportDownloadUrl = "https://adwords.google.com/api/adwords/reportdownload/"
+	baseReportDownloadUrl = "https://adwords.google.com/api/adwords/reportdownload/" + version
+	rootTrafficUrl        = "https://adwords.google.com/api/adwords/o/"
+	baseTrafficUrl        = "https://adwords.google.com/api/adwords/o/" + version
+)
+
+type ServiceUrl struct {
+	Url  string
+	Name string
+}
+
+// exceptions
+var (
+	ERROR_NOT_YET_IMPLEMENTED = fmt.Errorf("Not yet implemented")
+)
+
+var (
+
+	// service urls
+	adGroupAdServiceUrl               = ServiceUrl{baseUrl, "AdGroupAdService"}
+	adGroupBidModifierServiceUrl      = ServiceUrl{baseUrl, "AdGroupBidModifierService"}
+	adGroupCriterionServiceUrl        = ServiceUrl{baseUrl, "AdGroupCriterionService"}
+	adGroupExtensionSettingServiceUrl = ServiceUrl{baseUrl, "AdGroupExtensionSettingService"}
+	adGroupFeedServiceUrl             = ServiceUrl{baseUrl, "AdGroupFeedService"}
+	adGroupServiceUrl                 = ServiceUrl{baseUrl, "AdGroupService"}
+	adParamServiceUrl                 = ServiceUrl{baseUrl, "AdParamService"}
+	adwordsUserListServiceUrl         = ServiceUrl{baseRemarketingUrl, "AdwordsUserListService"}
+	batchJobServiceUrl                = ServiceUrl{baseUrl, "BatchJobService"}
+	biddingStrategyServiceUrl         = ServiceUrl{baseUrl, "BiddingStrategyService"}
+	budgetOrderServiceUrl             = ServiceUrl{baseUrl, "BudgetOrderService"}
+	budgetServiceUrl                  = ServiceUrl{baseUrl, "BudgetService"}
+	campaignExtensionSettingUrl       = ServiceUrl{baseUrl, "CampaignExtensionSettingService"}
+	campaignCriterionServiceUrl       = ServiceUrl{baseUrl, "CampaignCriterionService"}
+	campaignFeedServiceUrl            = ServiceUrl{baseUrl, "CampaignFeedService"}
+	campaignServiceUrl                = ServiceUrl{baseUrl, "CampaignService"}
+	campaignSharedSetServiceUrl       = ServiceUrl{baseUrl, "CampaignSharedSetService"}
+	constantDataServiceUrl            = ServiceUrl{baseUrl, "ConstantDataService"}
+	conversionTrackerServiceUrl       = ServiceUrl{baseUrl, "ConversionTrackerService"}
+	customerFeedServiceUrl            = ServiceUrl{baseUrl, "CustomerFeedService"}
+	customerServiceUrl                = ServiceUrl{baseMcmUrl, "CustomerService"}
+	customerSyncServiceUrl            = ServiceUrl{baseUrl, "CustomerSyncService"}
+	dataServiceUrl                    = ServiceUrl{baseUrl, "DataService"}
+	experimentServiceUrl              = ServiceUrl{baseUrl, "ExperimentService"}
+	feedItemServiceUrl                = ServiceUrl{baseUrl, "FeedItemService"}
+	feedMappingServiceUrl             = ServiceUrl{baseUrl, "FeedMappingService"}
+	feedServiceUrl                    = ServiceUrl{baseUrl, "FeedService"}
+	geoLocationServiceUrl             = ServiceUrl{baseUrl, "GeoLocationService"}
+	labelServiceUrl                   = ServiceUrl{baseUrl, "LabelService"}
+	locationCriterionServiceUrl       = ServiceUrl{baseUrl, "LocationCriterionService"}
+	managedCustomerServiceUrl         = ServiceUrl{baseMcmUrl, "ManagedCustomerService"}
+	mediaServiceUrl                   = ServiceUrl{baseUrl, "MediaService"}
+	mutateJobServiceUrl               = ServiceUrl{baseUrl, "MutateJobService"}
+	offlineConversionFeedServiceUrl   = ServiceUrl{baseUrl, "OfflineConversionFeedService"}
+	reportDefinitionServiceUrl        = ServiceUrl{baseUrl, "ReportDefinitionService"}
+	reportDownloadServiceUrl          = ServiceUrl{baseReportDownloadUrl, ""}
+	sharedCriterionServiceUrl         = ServiceUrl{baseUrl, "SharedCriterionService"}
+	sharedSetServiceUrl               = ServiceUrl{baseUrl, "SharedSetService"}
+	targetingIdeaServiceUrl           = ServiceUrl{baseTrafficUrl, "TargetingIdeaService"}
+	trafficEstimatorServiceUrl        = ServiceUrl{baseTrafficUrl, "TrafficEstimatorService"}
+)
+
+func (s ServiceUrl) String() string {
+	if s.Name != "" {
+		return s.Url + "/" + s.Name
+	}
+	return s.Url
+}
+
+type Auth struct {
+	CustomerId     string
+	DeveloperToken string
+	UserAgent      string
+	PartialFailure bool
+	Testing        *testing.T   `json:"-"`
+	Client         *http.Client `json:"-"`
+}
+
+//
+// Selector structs
+//
+type DateRange struct {
+	Min string `xml:"min"`
+	Max string `xml:"max"`
+}
+
+type Predicate struct {
+	Field    string   `xml:"field"`
+	Operator string   `xml:"operator"`
+	Values   []string `xml:"values"`
+}
+
+type OrderBy struct {
+	Field     string `xml:"field"`
+	SortOrder string `xml:"sortOrder"`
+}
+
+type Paging struct {
+	Offset int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 startIndex"`
+	Limit  int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 numberResults"`
+}
+
+type Selector struct {
+	XMLName    xml.Name
+	Fields     []string    `xml:"fields"`
+	Predicates []Predicate `xml:"predicates"`
+	DateRange  *DateRange  `xml:"dateRange,omitempty"`
+	Ordering   []OrderBy   `xml:"ordering"`
+	Paging     *Paging     `xml:"paging,omitempty"`
+}
+
+type AWQLQuery struct {
+	XMLName xml.Name
+	Query   string `xml:"query"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.DayOfWeek
+// Days of the week.
+// MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+type DayOfWeek string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.MinuteOfHour
+// Minutes in an hour. Currently only 0, 15, 30, and 45 are supported
+// ZERO, FIFTEEN, THIRTY, FORTY_FIVE
+type MinuteOfHour string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.GeoRestriction
+// A restriction used to determine if the request context's geo should be matched.
+// UNKNOWN, LOCATION_OF_PRESENCE
+type GeoRestriction string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.PolicyData
+// Approval and policy information attached to an entity.
+type PolicyData struct {
+	DisapprovalReasons []DisapprovalReason `xml:"https://adwords.google.com/api/adwords/cm/v201702 disapprovalReasons,omitempty"`
+	PolicyDataType     string              `xml:"https://adwords.google.com/api/adwords/cm/v201702 PolicyData.Type,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.DisapprovalReason
+// Container for information about why an AdWords entity was disapproved.
+type DisapprovalReason struct {
+	ShortName string `xml:"https://adwords.google.com/api/adwords/cm/v201702 shortName,omitempty"`
+}
+
+// error parsers
+func selectorError() (err error) {
+	return err
+}
+
+func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}) (respBody []byte, err error) {
+
+	type devToken struct {
+		XMLName xml.Name
+	}
+	type soapReqHeader struct {
+		XMLName          xml.Name
+		UserAgent        string `xml:"userAgent"`
+		DeveloperToken   string `xml:"developerToken"`
+		ClientCustomerId string `xml:"clientCustomerId,omitempty"`
+		PartialFailure   bool   `xml:"partialFailure,omitempty"`
+	}
+
+	type soapReqBody struct {
+		Body interface{}
+	}
+
+	type soapReqEnvelope struct {
+		XMLName xml.Name
+		Header  soapReqHeader `xml:"Header>RequestHeader"`
+		Body    soapReqBody   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
+	}
+
+	reqHead := soapReqHeader{
+		XMLName:          xml.Name{serviceUrl.Url, "RequestHeader"},
+		UserAgent:        a.UserAgent,
+		DeveloperToken:   a.DeveloperToken,
+		ClientCustomerId: a.CustomerId,
+	}
+
+	// https://developers.google.com/adwords/api/docs/guides/partial-failure
+	if a.PartialFailure {
+		reqHead.PartialFailure = true
+	}
+
+	reqBody, err := xml.MarshalIndent(
+		soapReqEnvelope{
+			XMLName: xml.Name{"http://schemas.xmlsoap.org/soap/envelope/", "Envelope"},
+			Header:  reqHead,
+			Body:    soapReqBody{body},
+		},
+		"  ", "  ")
+	if err != nil {
+		return []byte{}, err
+	}
+
+	req, err := http.NewRequest("POST", serviceUrl.String(), bytes.NewReader(reqBody))
+	req.Header.Add("Accept", "text/xml")
+	req.Header.Add("Accept", "multipart/*")
+	req.Header.Add("Content-Type", "text/xml;charset=UTF-8")
+	contentLength := fmt.Sprintf("%d", len(reqBody))
+	req.Header.Add("Content-length", contentLength)
+	req.Header.Add("SOAPAction", action)
+	if a.Testing != nil {
+		a.Testing.Logf("request ->\n%s\n%#v\n%s\n", req.URL.String(), req.Header, string(reqBody))
+	}
+
+	// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+	if level := os.Getenv("DEBUG"); level != "" {
+		fmt.Printf("request ->\n%s\n%#v\n%s\n", req.URL.String(), req.Header, string(reqBody))
+	}
+
+	resp, err := a.Client.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err = ioutil.ReadAll(resp.Body)
+
+	// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+	if level := os.Getenv("DEBUG"); level != "" {
+		fmt.Printf("response ->\n%s\n", string(respBody))
+	}
+
+	if a.Testing != nil {
+		a.Testing.Logf("respBody ->\n%s\n%s\n", string(respBody), resp.Status)
+	}
+
+	type soapRespHeader struct {
+		RequestId    string `xml:"requestId"`
+		ServiceName  string `xml:"serviceName"`
+		MethodName   string `xml:"methodName"`
+		Operations   int64  `xml:"operations"`
+		ResponseTime int64  `xml:"responseTime"`
+	}
+
+	type soapRespBody struct {
+		Response []byte `xml:",innerxml"`
+	}
+
+	soapResp := struct {
+		XMLName xml.Name       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+		Header  soapRespHeader `xml:"Header>RequestHeader"`
+		Body    soapRespBody   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &soapResp)
+	if err != nil {
+		return respBody, err
+	}
+	if resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 405 || resp.StatusCode == 500 {
+		fault := Fault{}
+		fmt.Printf("unknown error ->\n%s\n", string(soapResp.Body.Response))
+		err = xml.Unmarshal(soapResp.Body.Response, &fault)
+		if err != nil {
+			return respBody, err
+		}
+		return soapResp.Body.Response, &fault.Errors
+	}
+	return soapResp.Body.Response, err
+}

--- a/v201702/base_test.go
+++ b/v201702/base_test.go
@@ -1,0 +1,36 @@
+package v201702
+
+import (
+	"crypto/rand"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+func rand_str(str_size int) string {
+	alphanum := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}
+
+func rand_word(str_size int) string {
+	alphanum := "abcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}
+
+func testAuthSetup(t *testing.T) Auth {
+	config, err := NewCredentials(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Auth.Testing = t
+	return config.Auth
+}

--- a/v201702/basic_operation_test.go
+++ b/v201702/basic_operation_test.go
@@ -1,0 +1,559 @@
+package v201702
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"time"
+)
+
+func ExampleCampaignService_Get() {
+	// load credentials from
+	authConf, _ := NewCredentials(context.TODO())
+	cs := NewCampaignService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all the campaigns for an account.
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	totalCount := 0
+	for {
+		campaigns, totalCount, err := cs.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"Name",
+					"Status",
+				},
+				Ordering: []OrderBy{
+					{"Name", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding campaigns")
+		}
+		for _, c := range campaigns {
+			fmt.Printf("Campaign ID %d, name '%s' and status '%s'", c.Id, c.Name, c.Status)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+	fmt.Printf("\tTotal number of campaigns found: %d.", totalCount)
+}
+
+func ExampleCampaignService_Mutate() {
+	// load credentials from
+	authConf, err := NewCredentials(context.TODO())
+	cs := NewCampaignService(&authConf.Auth)
+
+	var budgetId int64 = 1
+
+	// This example illustrates how to create campaigns.
+	campaigns, err := cs.Mutate(
+		CampaignOperations{
+			"ADD": {
+				Campaign{
+					Name:   fmt.Sprintf("Interplanetary Cruise #%d", time.Now().Unix()),
+					Status: "ACTIVE",
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+					// Budget (required) - note only the budget ID is required
+					BudgetId:               budgetId,
+					AdvertisingChannelType: "SEARCH",
+					// Optional Fields:
+					StartDate:                   time.Now().Format("20060102"),
+					AdServingOptimizationStatus: "ROTATE",
+					NetworkSetting: &NetworkSetting{
+						TargetGoogleSearch:         true,
+						TargetSearchNetwork:        true,
+						TargetContentNetwork:       false,
+						TargetPartnerSearchNetwork: false,
+					},
+					Settings: []CampaignSetting{
+						NewGeoTargetTypeSetting(
+							"DONT_CARE",
+							"DONT_CARE",
+						),
+					},
+					FrequencyCap: &FrequencyCap{
+						Impressions: 5,
+						TimeUnit:    "DAY",
+						Level:       "ADGROUP",
+					},
+				},
+				Campaign{
+					Name:   fmt.Sprintf("Interplanetary Cruise banner #%d", time.Now().Unix()),
+					Status: "PAUSED",
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+					// Budget (required) - note only the budget ID is required
+					BudgetId:               budgetId,
+					AdvertisingChannelType: "DISPLAY",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error occured creating campaign.")
+	}
+	for _, c := range campaigns {
+		fmt.Printf("Campaign with name '%s' and ID %d was added.", c.Name, c.Id)
+	}
+
+	// This example illustrates how to update a campaign, setting its status to 'PAUSED'
+	campaigns, err = cs.Mutate(
+		CampaignOperations{
+			"SET": {
+				Campaign{
+					Id:     campaigns[0].Id,
+					Status: "PAUSED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No campaigns were updated.")
+	} else {
+		fmt.Printf("Campaign ID %d was successfully updated, status was set to '%s'.", campaigns[0].Id, campaigns[0].Status)
+	}
+
+	// This example removes a campaign by setting the status to 'REMOVED'.
+	campaigns, err = cs.Mutate(
+		CampaignOperations{
+			"SET": {
+				Campaign{
+					Id:     campaigns[0].Id,
+					Status: "REMOVED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No campaigns were updated.")
+	} else {
+		fmt.Printf("Campaign ID %d was removed.", campaigns[0].Id)
+	}
+}
+
+func ExampleAdGroupService_Get() {
+	authConf, _ := NewCredentials(context.TODO())
+	ags := NewAdGroupService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all the ad groups for a campaign.
+	campaignId := "3"
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	totalCount := 0
+	for {
+		adGroups, totalCount, err := ags.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"Name",
+				},
+				Ordering: []OrderBy{
+					{"Name", "ASCENDING"},
+				},
+				Predicates: []Predicate{
+					{"CampaignId", "IN", []string{campaignId}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding ad group")
+		}
+		for _, ag := range adGroups {
+			fmt.Printf("Ad group name is '%s' and ID is %d", ag.Id, ag.Name)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+	fmt.Printf("\tCampaign ID %d has %d ad group(s).", campaignId, totalCount)
+}
+
+func ExampleAdGroupService_Mutate() {
+	authConf, err := NewCredentials(context.TODO())
+	ags := NewAdGroupService(&authConf.Auth)
+
+	var campaignId int64 = 1
+
+	// This example illustrates how to create ad groups.
+	adGroups, err := ags.Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       fmt.Sprintf("Earth to Mars Cruises #%d", time.Now().Unix()),
+					Status:     "ENABLED",
+					CampaignId: campaignId,
+					BiddingStrategyConfiguration: []BiddingStrategyConfiguration{
+						{
+							Bids: []Bid{
+								Bid{
+									Type:   "CpcBid",
+									Amount: 10000000,
+								},
+							},
+						},
+					},
+					Settings: []AdSetting{
+						AdSetting{
+							Details: []TargetSettingDetail{
+								TargetSettingDetail{
+									CriterionTypeGroup: "PLACEMENT",
+									TargetAll:          true,
+								},
+								TargetSettingDetail{
+									CriterionTypeGroup: "VERTICAL",
+									TargetAll:          false,
+								},
+							},
+						},
+					},
+				},
+				AdGroup{
+					Name:       fmt.Sprintf("Earth to Pluto Cruises #%d", time.Now().Unix()),
+					Status:     "ENABLED",
+					CampaignId: campaignId,
+					BiddingStrategyConfiguration: []BiddingStrategyConfiguration{
+						{
+							Bids: []Bid{
+								Bid{
+									Type:   "CpcBid",
+									Amount: 10000000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("")
+	} else {
+		for _, ag := range adGroups {
+			fmt.Printf("Ad group ID %d was successfully added.", ag.Id)
+		}
+	}
+
+	// This example illustrates how to update an ad group
+	adGroups, err = ags.Mutate(
+		AdGroupOperations{
+			"SET": {
+				AdGroup{
+					Id:     adGroups[0].Id,
+					Status: "PAUSE",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ad groups were updated.")
+	} else {
+		fmt.Printf("Ad group id %d was successfully updated.", adGroups[0].Id)
+	}
+
+	// This example removes an ad group by setting the status to 'REMOVED'.
+	adGroups, err = ags.Mutate(
+		AdGroupOperations{
+			"SET": {
+				AdGroup{
+					Id:     adGroups[0].Id,
+					Status: "REMOVE",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ad groups were updated.")
+	} else {
+		fmt.Printf("Ad group id %d was successfully removed.", adGroups[0].Id)
+	}
+}
+
+func ExampleAdGroupCriterionService_Get() {
+	authConf, _ := NewCredentials(context.TODO())
+	agcs := NewAdGroupCriterionService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all keywords for an ad group.
+	adGroupId := "1"
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	for {
+		adGroupCriterions, totalCount, err := agcs.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"CriteriaType",
+					"KeywordText",
+				},
+				Ordering: []OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Predicates: []Predicate{
+					{"AdGroupId", "EQUALS", []string{adGroupId}},
+					{"CriteriaType", "EQUALS", []string{"KEYWORD"}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding ad group criterion")
+		}
+		for _, agc := range adGroupCriterions {
+			kc := agc.(BiddableAdGroupCriterion).Criterion.(KeywordCriterion)
+			fmt.Printf("Keyword ID %d, type '%s' and text '%s'", kc.Id, kc.MatchType, kc.Text)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			fmt.Printf("\tAd group ID %d has %d keyword(s).", totalCount)
+			break
+		}
+	}
+}
+
+func ExampleAdGroupCriterionService_Mutate() {
+	authConf, err := NewCredentials(context.TODO())
+	agcs := NewAdGroupCriterionService(&authConf.Auth)
+
+	var adGroupId int64 = 1
+
+	// This example illustrates how to add multiple keywords to a given ad group.
+	adGroupCriterions, err := agcs.Mutate(
+		AdGroupCriterionOperations{
+			"ADD": {
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroupId,
+					Criterion: KeywordCriterion{
+						Text:      "mars cruise",
+						MatchType: "BROAD",
+					},
+					UserStatus:     "PAUSED",
+					DestinationUrl: "http://example.com/mars",
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroupId,
+					Criterion: KeywordCriterion{
+						Text:      "space hotel",
+						MatchType: "BROAD",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No keywords were added.")
+	} else {
+		fmt.Printf("Added %d keywords to ad group ID %d:", len(adGroupCriterions), adGroupId)
+		for _, agc := range adGroupCriterions {
+			k := agc.(BiddableAdGroupCriterion).Criterion.(KeywordCriterion)
+			fmt.Printf("\tKeyword ID is %d and type is '%s'", k.Id, k.MatchType)
+		}
+	}
+
+	// This example updates the bid of a keyword.
+	keywordCriterion := adGroupCriterions[0].(BiddableAdGroupCriterion).Criterion.(KeywordCriterion)
+	biddingStrategyConfigurations := BiddingStrategyConfiguration{
+		Bids: []Bid{
+			Bid{
+				Type:   "CpcBid",
+				Amount: 10000000,
+			},
+		},
+	}
+	adGroupCriterions, err = agcs.Mutate(
+		AdGroupCriterionOperations{
+			"SET": {
+				BiddableAdGroupCriterion{
+					AdGroupId:                    adGroupId,
+					Criterion:                    keywordCriterion,
+					BiddingStrategyConfiguration: &biddingStrategyConfigurations,
+				},
+			},
+		},
+	)
+	biddableAdGroupCriterion := adGroupCriterions[0].(BiddableAdGroupCriterion)
+	keywordCriterion = biddableAdGroupCriterion.Criterion.(KeywordCriterion)
+	if err != nil {
+		fmt.Printf("No keywords were updated.")
+	} else {
+		fmt.Printf("Keyword ID %d was successfully updated, current bids are:", keywordCriterion.Id)
+		for _, bid := range biddableAdGroupCriterion.BiddingStrategyConfiguration.Bids {
+			fmt.Printf("\tType: '%s', value: %d", bid.Type, bid.Amount)
+		}
+	}
+
+	// This example removes a keyword using the 'REMOVE' operator.
+	adGroupCriterions, err = agcs.Mutate(
+		AdGroupCriterionOperations{
+			"REMOVE": {
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroupId,
+					Criterion: keywordCriterion,
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No keywords were removed.")
+	} else {
+		biddableAdGroupCriterion := adGroupCriterions[0].(BiddableAdGroupCriterion)
+		keywordCriterion = biddableAdGroupCriterion.Criterion.(KeywordCriterion)
+		fmt.Printf("Keyword ID %d was successfully removed.", keywordCriterion.Id)
+	}
+}
+
+func ExampleAdGroupAdService_Get() {
+	authConf, _ := NewCredentials(context.TODO())
+	agas := NewAdGroupAdService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all text ads for an ad group.
+	adGroupId := "1"
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	var totalCount int64 = 0
+	for {
+		adGroupAds, totalCount, err := agas.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"Status",
+					"AdType",
+				},
+				Ordering: []OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Predicates: []Predicate{
+					{"AdGroupId", "IN", []string{adGroupId}},
+					{"Status", "IN", []string{"ENABLED", "PAUSED", "DISABLED"}},
+					{"AdType", "EQUALS", []string{"TEXT_AD"}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding ad group ad")
+		}
+		for _, aga := range adGroupAds {
+			ta := aga.(TextAd)
+			fmt.Printf("Ad ID is %d, type is 'TextAd' and status is '%s'", ta.Id, ta.Status)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+	fmt.Printf("\tAd group ID %d has %d ad(s).", totalCount)
+}
+
+func ExampleAdGroupAdService_Mutate() {
+	authConf, err := NewCredentials(context.TODO())
+	agas := NewAdGroupAdService(&authConf.Auth)
+
+	// This example illustrates how to add text ads to a given ad group.
+	var adGroupId int64 = 1
+
+	adGroupAds, err := agas.Mutate(
+		AdGroupAdOperations{
+			"ADD": {
+				NewTextAd(
+					adGroupId,
+					"http://www.example.com",
+					"example.com",
+					"Luxury Cruise to Mars",
+					"Visit the Red Planet in style.",
+					"Low-gravity fun for everyone!",
+					"ACTIVE",
+				),
+				NewTextAd(
+					adGroupId,
+					"http://www.example.com",
+					"www.example.com",
+					"Luxury Cruise to Mars",
+					"Enjoy your stay at Red Planet.",
+					"Buy your tickets now!",
+					"ACTIVE",
+				),
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ads were added.")
+	} else {
+		fmt.Printf("Added %d ad(s) to ad group ID %d:", len(adGroupAds), adGroupId)
+		for _, ada := range adGroupAds {
+			ta := ada.(TextAd)
+			fmt.Printf("\tAd ID %d, type 'TextAd' and status '%s'", ta.Id, ta.Status)
+		}
+	}
+
+	// This example illustrates how to update an ad, setting its status to 'PAUSED'.
+	textAdId := adGroupAds[0].(TextAd).Id
+	adGroupAds, err = agas.Mutate(
+		AdGroupAdOperations{
+			"SET": {
+				TextAd{
+					AdGroupId: adGroupId,
+					Id:        textAdId,
+					Status:    "PAUSED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ads were updated.")
+	} else {
+		textAd := adGroupAds[0].(TextAd)
+		fmt.Printf("Ad ID %d was successfully updated, status set to '%s'.", textAd.Id, textAd.Status)
+	}
+
+	// This example removes an ad using the 'REMOVE' operator.
+	adGroupAds, err = agas.Mutate(
+		AdGroupAdOperations{
+			"SET": {
+				TextAd{
+					AdGroupId: adGroupId,
+					Id:        textAdId,
+					Status:    "REMOVE",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ads were removed.")
+	} else {
+		textAd := adGroupAds[0].(TextAd)
+		fmt.Printf("Ad ID %d was successfully removed.", textAd.Id)
+	}
+}

--- a/v201702/batch_job.go
+++ b/v201702/batch_job.go
@@ -1,0 +1,316 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type BatchJobService struct {
+	Auth
+}
+
+type BatchJobPage struct {
+	TotalNumEntries int        `xml:"rval>totalNumEntries"`
+	BatchJobs       []BatchJob `xml:"rval>entries"`
+}
+
+type BatchJobOperations struct {
+	BatchJobOperations []BatchJobOperation
+}
+
+type Operation struct {
+	Operator string      `xml:"https://adwords.google.com/api/adwords/cm/v201702 operator"`
+	Operand  interface{} `xml:"operand"`
+	Xsi_type string      `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+}
+
+type BatchJobOperation struct {
+	Operator string   `xml:"operator"`
+	Operand  BatchJob `xml:"operand"`
+}
+
+type BatchJob struct {
+	Id               int64                    `xml:"id,omitempty" json:",string"`
+	Status           string                   `xml:"status,omitempty"`
+	ProgressStats    *ProgressStats           `xml:"progressStats,omitempty"`
+	UploadUrl        *TemporaryUrl            `xml:"uploadUrl,omitempty"`
+	DownloadUrl      *TemporaryUrl            `xml:"downloadUrl,omitempty"`
+	ProcessingErrors *BatchJobProcessingError `xml:"processingErrors,omitempty"`
+}
+
+type TemporaryUrl struct {
+	Url        string `xml:"url"`
+	Expiration string `xml:"expiration,"`
+}
+
+type BatchJobProcessingError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type ProgressStats struct {
+	NumOperationsExecuted    int64 `xml:"numOperationsExecuted" json:",string"`
+	NumOperationsSucceeded   int64 `xml:"numOperationsSucceeded" json:",string"`
+	EstimatedPercentExecuted int   `xml:"estimatedPercentExecuted"`
+	NumResultsWritten        int64 `xml:"numResultsWritten" json:",string"`
+}
+
+type MutateResults struct {
+	Result    MutateResult   `xml:"result"`
+	ErrorList []MutateErrors `xml:"errorList"`
+	Index     int            `xml:"index"`
+}
+
+type MutateErrors struct {
+	Errors EntityError `xml:"errors"`
+}
+
+type MutateResult interface{}
+
+func NewBatchJobService(auth *Auth) *BatchJobService {
+	return &BatchJobService{Auth: *auth}
+}
+
+// Get queries the status of existing BatchJobs
+//
+//	Example
+//
+//	batchJobs, err := batchJobService.Get(
+// 		gads.Selector{
+//			Fields: []string{
+//				"Id",
+//				"Status",
+//				"DownloadUrl",
+//				"ProcessingErrors",
+//				"ProgressStats",
+//			},
+//			Predicates: []gads.Predicate{
+//				{"Id", "EQUALS", []string{strconv.FormatInt(jobId, 10)}},
+//			},
+//		},
+//	)
+//
+// 	https://developers.google.com/adwords/api/docs/reference/v201702/BatchJobService#get
+func (s *BatchJobService) Get(selector Selector) (batchJobPage BatchJobPage, err error) {
+
+	selector.XMLName = xml.Name{baseUrl, "selector"}
+	respBody, err := s.Auth.request(
+		batchJobServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return batchJobPage, err
+	}
+
+	err = xml.Unmarshal([]byte(respBody), &batchJobPage)
+
+	return batchJobPage, err
+}
+
+// Mutate allows you to create or update a BatchJob
+//
+//	Example
+//
+//	resp, err := batchJobService.Mutate(
+// 		gads.BatchJobOperations{
+//			BatchJobOperations: []gads.BatchJobOperation{
+//				gads.BatchJobOperation{
+//					Operator: "ADD",
+//					Operand: gads.BatchJob{},
+//				},
+//			},
+//		},
+//	)
+//
+// 	https://developers.google.com/adwords/api/docs/reference/v201702/BatchJobService#mutate
+func (s *BatchJobService) Mutate(batchJobOperations BatchJobOperations) (batchJobs []BatchJob, err error) {
+
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []BatchJobOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: batchJobOperations.BatchJobOperations}
+	respBody, err := s.Auth.request(batchJobServiceUrl, "mutate", mutation)
+	if err != nil {
+		return batchJobs, err
+	}
+	mutateResp := struct {
+		BatchJobs []BatchJob `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return batchJobs, err
+	}
+
+	return mutateResp.BatchJobs, err
+}
+
+func (s *BatchJobService) Query() {
+
+}
+
+func (mr *MutateResults) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "index":
+				if err := dec.DecodeElement(&mr.Index, &start); err != nil {
+					return err
+				}
+			case "errorList":
+				if err := dec.DecodeElement(&mr.ErrorList, &start); err != nil {
+					return err
+				}
+			case "AdGroup":
+				ag := AdGroup{}
+				err := dec.DecodeElement(&ag, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = ag
+			case "AdGroupAd":
+				aga := AdGroupAds{}
+				err := dec.DecodeElement(&aga, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = aga
+			case "AdGroupAdLabel":
+				agal := AdGroupAdLabel{}
+				err := dec.DecodeElement(&agal, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agal
+			case "AdGroupCriterion":
+				agc := AdGroupCriterions{}
+				err := dec.DecodeElement(&agc, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agc
+			case "AdGroupCriterionLabel":
+				agcl := AdGroupCriterionLabel{}
+				err := dec.DecodeElement(&agcl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agcl
+			case "AdGroupExtensionSetting":
+				cl := AdGroupExtensionSetting{}
+				err := dec.DecodeElement(&cl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cl
+			case "AdGroupLabel":
+				agl := AdGroupLabel{}
+				err := dec.DecodeElement(&agl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agl
+			case "Budget":
+				b := Budget{}
+				err := dec.DecodeElement(&b, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = b
+			case "Campaign":
+				c := Campaign{}
+				err := dec.DecodeElement(&c, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = c
+			case "CampaignCriterion":
+				cc := CampaignCriterions{}
+				err := dec.DecodeElement(&cc, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cc
+			case "CampaignExtensionSetting":
+				cl := CampaignExtensionSetting{}
+				err := dec.DecodeElement(&cl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cl
+			case "CampaignLabel":
+				cl := CampaignLabel{}
+				err := dec.DecodeElement(&cl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cl
+			case "result":
+				break
+			default:
+				return fmt.Errorf("unknown MutateResults field %s", tag)
+			}
+		}
+	}
+	return err
+}
+
+// getXsiType validates the schema instance type and returns it since Bulk Mutate requires it to be set
+func getXsiType(objectName string) (string, bool) {
+	switch {
+	case strings.Contains(objectName, "AdGroupExtensionSettingOperation"):
+		return "AdGroupExtensionSettingOperation", true
+	case strings.Contains(objectName, "AdGroupAdLabelOperation"):
+		return "AdGroupAdLabelOperation", true
+	case strings.Contains(objectName, "AdGroupAdOperation"):
+		return "AdGroupAdOperation", true
+	case strings.Contains(objectName, "AdGroupBidModifierOperation"):
+		return "AdGroupBidModifierOperation", true
+	case strings.Contains(objectName, "AdGroupCriterionLabelOperation"):
+		return "AdGroupCriterionLabelOperation", true
+	case strings.Contains(objectName, "AdGroupCriterionOperation"):
+		return "AdGroupCriterionOperation", true
+	case strings.Contains(objectName, "AdGroupLabelOperation"):
+		return "AdGroupLabelOperation", true
+	case strings.Contains(objectName, "AdGroupOperation"):
+		return "AdGroupOperation", true
+	case strings.Contains(objectName, "BudgetOperation"):
+		return "BudgetOperation", true
+	case strings.Contains(objectName, "CampaignAdExtensionOperation"):
+		return "CampaignAdExtensionOperation", true
+	case strings.Contains(objectName, "CampaignExtensionSettingOperation"):
+		return "CampaignExtensionSettingOperation", true
+	case strings.Contains(objectName, "CampaignCriterionOperation"):
+		return "CampaignCriterionOperation", true
+	case strings.Contains(objectName, "CampaignLabelOperation"):
+		return "CampaignLabelOperation", true
+	case strings.Contains(objectName, "CampaignOperation"):
+		return "CampaignOperation", true
+	case strings.Contains(objectName, "FeedItemOperation"):
+		return "FeedItemOperation", true
+	default:
+		return "", false
+	}
+}

--- a/v201702/batch_job_helper.go
+++ b/v201702/batch_job_helper.go
@@ -1,0 +1,193 @@
+package v201702
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+)
+
+type BatchJobHelper struct {
+	Auth
+}
+
+func NewBatchJobHelper(auth *Auth) *BatchJobHelper {
+	return &BatchJobHelper{Auth: *auth}
+}
+
+//	UploadBatchJobOperations uploads batch operations to an BatchJob.UploadUrl from BatchJobService.Mutate
+//
+//	Example
+//
+//	ago := gads.AdGroupOperations{
+//			"ADD": {
+//				gads.AdGroup{
+// 					Name:       "test ad group " + rand_str(10),
+// 					Status:     "PAUSED",
+// 					CampaignId: campaignId,
+// 				},
+// 				gads.AdGroup{
+// 					Name:       "test ad group " + rand_str(10),
+// 					Status:     "PAUSED",
+// 					CampaignId: campaignId,
+// 				},
+// 			},
+// 		}
+//
+//	var operations []interface{}
+//	operations = append(operations, ago)
+//	err = batchJobHelper.UploadBatchJobOperations(operations, UploadUrl)
+//
+//
+//	https://developers.google.com/adwords/api/docs/guides/batch-jobs?hl=en#upload_operations_to_the_upload_url
+func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, url TemporaryUrl) (err error) {
+
+	var operations []Operation
+	for _, operation := range jobOperations {
+		if operationType, valid := getXsiType(reflect.ValueOf(operation).Type().String()); valid {
+			switch reflect.TypeOf(operation).Kind() {
+			case reflect.Map:
+				ops := reflect.ValueOf(operation)
+
+				keys := ops.MapKeys()
+
+				for _, action := range keys {
+					jobs := ops.MapIndex(action)
+
+					for i := 0; i < jobs.Len(); i++ {
+
+						operations = append(operations,
+							Operation{
+								Operator: action.String(),
+								Operand:  jobs.Index(i).Interface(),
+								Xsi_type: operationType,
+							},
+						)
+					}
+				}
+			}
+		}
+	}
+
+	if len(operations) > 0 {
+		mutation := struct {
+			XMLName xml.Name
+			Ops     []Operation `xml:"operations"`
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "mutate",
+			},
+			Ops: operations,
+		}
+
+		client := &http.Client{}
+
+		// Need to get the upload url
+		req, err := http.NewRequest("POST", url.Url, nil)
+		if err != nil {
+			return err
+		}
+
+		req.Header.Set("Content-Type", "application/xml")
+		req.Header.Set("Content-Length", "0")
+		req.Header.Set("x-goog-resumable", "start")
+
+		response, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer response.Body.Close()
+
+		// If we got a valid upload url it will be 201
+		if response.StatusCode != http.StatusCreated {
+			respBody, err := ioutil.ReadAll(response.Body)
+
+			if err != nil {
+				return err
+			}
+			return errors.New(fmt.Sprintf("Invalid response received. %v received. Body: %v", response.StatusCode, string(respBody)))
+		}
+
+		location := response.Header.Get("Location")
+
+		reqBody, err := xml.MarshalIndent(mutation, "  ", "  ")
+		bodyLength := len(reqBody)
+
+		if err != nil {
+			return err
+		}
+
+		req, err = http.NewRequest("PUT", location, bytes.NewReader(reqBody))
+
+		if err != nil {
+			return err
+		}
+
+		// Set headers for incremental upload
+		req.Header.Set("Content-Type", "application/xml")
+		req.Header.Set("Content-Length", string(bodyLength))
+		req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%v/%v", bodyLength-1, bodyLength))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		respBody, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return err
+		}
+
+		// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+		if level := os.Getenv("DEBUG"); level != "" {
+			fmt.Printf("response ->\n%s\n", string(respBody))
+		}
+
+		// resp seems to only return 200's and there is no error handling, but if we happen to get invalid status lets try to do something with it
+		if resp.StatusCode != http.StatusOK {
+			return errors.New("Non-200 response returned Body: " + string(respBody))
+		}
+	}
+
+	return err
+}
+
+//	DownloadBatchJob download batch operations from an BatchJob.DownloadUrl from BatchJobService.Get
+//
+//	Example
+//
+//	mutateResult, err := batchJobHelper.DownloadBatchJob(*batchJobs.BatchJobs[0].DownloadUrl)
+//
+//	https://developers.google.com/adwords/api/docs/guides/batch-jobs?hl=en#download_the_batch_job_results_and_check_for_errors
+func (s *BatchJobHelper) DownloadBatchJob(url TemporaryUrl) (mutateResults []MutateResults, err error) {
+	resp, err := http.Get(url.Url)
+
+	if err != nil {
+		return mutateResults, err
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+
+	// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+	if level := os.Getenv("DEBUG"); level != "" {
+		fmt.Printf("response ->\n%s\n", string(respBody))
+	}
+
+	soapResp := struct {
+		MutateResults []MutateResults `xml:"rval"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &soapResp)
+	if err != nil {
+		return mutateResults, err
+	}
+
+	return soapResp.MutateResults, err
+}

--- a/v201702/biddable_ad_group_criterion.go
+++ b/v201702/biddable_ad_group_criterion.go
@@ -1,0 +1,158 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type BiddableAdGroupCriterion struct {
+	AdGroupId    int64     `xml:"adGroupId"`
+	CriterionUse string    `xml:"criterionUse"`
+	Criterion    Criterion `xml:"criterion"`
+
+	// BiddableAdGroupCriterion
+	UserStatus          string   `xml:"userStatus,omitempty"`
+	SystemServingStatus string   `xml:"systemServingStatus,omitempty"`
+	ApprovalStatus      string   `xml:"approvalStatus,omitempty"`
+	DisapprovalReasons  []string `xml:"disapprovalReasons,omitempty"`
+	DestinationUrl      string   `xml:"destinationUrl,omitempty"`
+
+	// TODO add ExperimentData
+	FirstPageCpc *Cpc `xml:"firstPageCpc,omitempty"`
+	TopOfPageCpc *Cpc `xml:"topOfPageCpc,omitempty"`
+
+	QualityInfo *QualityInfo `xml:"qualityInfo,omitempty"`
+
+	BiddingStrategyConfiguration *BiddingStrategyConfiguration `xml:"biddingStrategyConfiguration,omitempty"`
+	BidModifier                  int64                         `xml:"bidModifier,omitempty"`
+
+	FinalUrls           []string         `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string         `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []string         `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string           `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Labels              []Label          `xml:"labels,omitempty"`
+}
+
+func (bagc BiddableAdGroupCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"BiddableAdGroupCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&bagc.AdGroupId, xml.StartElement{Name: xml.Name{baseUrl, "adGroupId"}})
+	criterionMarshalXML(bagc.Criterion, e)
+	if bagc.UserStatus != "" {
+		e.EncodeElement(&bagc.UserStatus, xml.StartElement{Name: xml.Name{baseUrl, "userStatus"}})
+	}
+	if bagc.DestinationUrl != "" {
+		e.EncodeElement(&bagc.DestinationUrl, xml.StartElement{Name: xml.Name{baseUrl, "destinationUrl"}})
+	}
+	e.EncodeElement(&bagc.BiddingStrategyConfiguration, xml.StartElement{Name: xml.Name{baseUrl, "biddingStrategyConfiguration"}})
+	if bagc.BidModifier != 0 {
+		e.EncodeElement(&bagc.BidModifier, xml.StartElement{Name: xml.Name{baseUrl, "bidModifier"}})
+	}
+	e.EncodeElement(&bagc.UrlCustomParameters, xml.StartElement{Name: xml.Name{baseUrl, "urlCustomParameters"}})
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (bagc *BiddableAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "adGroupId":
+				if err := dec.DecodeElement(&bagc.AdGroupId, &start); err != nil {
+					return err
+				}
+			case "criterionUse":
+				if err := dec.DecodeElement(&bagc.CriterionUse, &start); err != nil {
+					return err
+				}
+			case "criterion":
+				criterion, err := criterionUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				bagc.Criterion = criterion
+			case "userStatus":
+				if err := dec.DecodeElement(&bagc.UserStatus, &start); err != nil {
+					return err
+				}
+			case "systemServingStatus":
+				if err := dec.DecodeElement(&bagc.SystemServingStatus, &start); err != nil {
+					return err
+				}
+			case "approvalStatus":
+				if err := dec.DecodeElement(&bagc.ApprovalStatus, &start); err != nil {
+					return err
+				}
+			case "disapprovalReasons":
+				if err := dec.DecodeElement(&bagc.DisapprovalReasons, &start); err != nil {
+					return err
+				}
+			case "destinationUrl":
+				if err := dec.DecodeElement(&bagc.DestinationUrl, &start); err != nil {
+					return err
+				}
+			case "firstPageCpc":
+				if err := dec.DecodeElement(&bagc.FirstPageCpc, &start); err != nil {
+					return err
+				}
+			case "topOfPageCpc":
+				if err := dec.DecodeElement(&bagc.TopOfPageCpc, &start); err != nil {
+					return err
+				}
+			case "qualityInfo":
+				if err := dec.DecodeElement(&bagc.QualityInfo, &start); err != nil {
+					return err
+				}
+			case "biddingStrategyConfiguration":
+				if err := dec.DecodeElement(&bagc.BiddingStrategyConfiguration, &start); err != nil {
+					return err
+				}
+			case "bidModifier":
+				if err := dec.DecodeElement(&bagc.BidModifier, &start); err != nil {
+					return err
+				}
+			case "finalUrls":
+				if err := dec.DecodeElement(&bagc.FinalUrls, &start); err != nil {
+					return err
+				}
+			case "finalMobileUrls":
+				if err := dec.DecodeElement(&bagc.FinalMobileUrls, &start); err != nil {
+					return err
+				}
+			case "finalAppUrls":
+				if err := dec.DecodeElement(&bagc.FinalAppUrls, &start); err != nil {
+					return err
+				}
+			case "trackingUrlTemplate":
+				if err := dec.DecodeElement(&bagc.TrackingUrlTemplate, &start); err != nil {
+					return err
+				}
+			case "urlCustomParameters":
+				if err := dec.DecodeElement(&bagc.UrlCustomParameters, &start); err != nil {
+					return err
+				}
+			case "labels":
+				if err := dec.DecodeElement(&bagc.Labels, &start); err != nil {
+					return err
+				}
+			case "AdGroupCriterion.Type":
+				break
+			default:
+				return fmt.Errorf("unknown BiddableAdGroupCriterion field %s", tag)
+			}
+		}
+	}
+	return nil
+}

--- a/v201702/bidding_strategy.go
+++ b/v201702/bidding_strategy.go
@@ -1,0 +1,24 @@
+package v201702
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type BiddingStrategyService struct {
+	Auth
+}
+
+func NewBiddingStrategyService(auth *Auth) *BiddingStrategyService {
+	return &BiddingStrategyService{Auth: *auth}
+}
+
+/*
+type AdGroupBidModifier struct {
+  CampaignId        int64     `xml:"campaignId"`
+  AdGroupId         int64     `xml:"adGroupId"`
+  Criterion         Criterion `xml:"criterion"`
+  BidModifier       float64   `xml:"bidModifier"`
+  BidModifierSource string    `xml:"bidModifierSource"`
+}
+*/

--- a/v201702/budget.go
+++ b/v201702/budget.go
@@ -1,0 +1,113 @@
+package v201702
+
+import (
+	"encoding/xml"
+	//  "fmt"
+)
+
+// A budgetService holds the connection information for the
+// budget service.
+type BudgetService struct {
+	Auth
+}
+
+// NewBudgetService creates a new budgetService
+func NewBudgetService(auth *Auth) *BudgetService {
+	return &BudgetService{Auth: *auth}
+}
+
+// A Budget represents an allotment of money to be spent over a fixed
+// period of time.
+type Budget struct {
+	Id         int64  `xml:"budgetId,omitempty"`           // A unique identifier
+	Name       string `xml:"name"`                         // A descriptive name
+	Period     string `xml:"period"`                       // The period to spend the budget
+	Amount     int64  `xml:"amount>microAmount"`           // The amount in cents
+	Delivery   string `xml:"deliveryMethod"`               // The rate at which the budget spent. valid options are STANDARD or ACCELERATED.
+	References int64  `xml:"referenceCount,omitempty"`     // The number of campaigns using the budget
+	Shared     bool   `xml:"isExplicitlyShared,omitempty"` // If this budget was created to be shared across campaigns
+	Status     string `xml:"status,omitempty"`             // The status of the budget. can be ENABLED, REMOVED, UNKNOWN
+}
+
+// A BudgetOperations maps operations to the budgets they will be performed
+// on.  Budgets operations can be 'ADD', 'REMOVE' or 'SET'
+type BudgetOperations map[string][]Budget
+
+func budgetError() (err error) {
+	return err
+}
+
+// Get returns budgets matching a given selector and the total count of matching budgets.
+func (s *BudgetService) Get(selector Selector) (budgets []Budget, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "selector"}
+	respBody, err := s.Auth.request(
+		budgetServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return budgets, totalCount, err
+	}
+	getResp := struct {
+		Size    int64    `xml:"rval>totalNumEntries"`
+		Budgets []Budget `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return budgets, totalCount, err
+	}
+	return getResp.Budgets, getResp.Size, err
+}
+
+// Mutate takes a budgetOperations and creates, modifies or destroys the associated budgets.
+func (s *BudgetService) Mutate(budgetOperations BudgetOperations) (budgets []Budget, err error) {
+	type budgetOperation struct {
+		Action string `xml:"operator"`
+		Budget Budget `xml:"operand"`
+	}
+	operations := []budgetOperation{}
+	for action, budgets := range budgetOperations {
+		for _, budget := range budgets {
+			operations = append(operations,
+				budgetOperation{
+					Action: action,
+					Budget: budget,
+				},
+			)
+		}
+	}
+	respBody, err := s.Auth.request(
+		budgetServiceUrl,
+		"mutate",
+		struct {
+			XMLName xml.Name
+			Ops     []budgetOperation `xml:"operations"`
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "mutate",
+			},
+			Ops: operations,
+		},
+	)
+	if err != nil {
+		return budgets, err
+	}
+	mutateResp := struct {
+		Budgets []Budget `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return budgets, err
+	}
+	return mutateResp.Budgets, err
+}

--- a/v201702/budget_order.go
+++ b/v201702/budget_order.go
@@ -1,0 +1,14 @@
+package v201702
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type BudgetOrderService struct {
+	Auth
+}
+
+func NewBudgetOrderService(auth *Auth) *BudgetOrderService {
+	return &BudgetOrderService{Auth: *auth}
+}

--- a/v201702/budget_test.go
+++ b/v201702/budget_test.go
@@ -1,0 +1,111 @@
+package v201702
+
+import (
+	"testing"
+)
+
+func testBudgetService(t *testing.T) (service *BudgetService) {
+	return &BudgetService{Auth: testAuthSetup(t)}
+}
+
+func testBudget(t *testing.T) (Budget, func()) {
+	s := testBudgetService(t)
+	budgets, err := s.Mutate(
+		BudgetOperations{
+			"ADD": {
+				Budget{
+					Name:     "testbudget " + rand_str(10),
+					Period:   "DAILY",
+					Amount:   50000000,
+					Delivery: "STANDARD",
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupBudget := func() {
+		_, err = s.Mutate(BudgetOperations{"REMOVE": budgets})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	return budgets[0], cleanupBudget
+}
+
+func TestBudget(t *testing.T) {
+	s := testBudgetService(t)
+	budgets, err := s.Mutate(
+		BudgetOperations{
+			"ADD": {
+				Budget{
+					Name:     "testbudget " + rand_str(10),
+					Period:   "DAILY",
+					Amount:   50000000,
+					Delivery: "STANDARD",
+				},
+				Budget{
+					Name:     "test budget " + rand_str(10),
+					Period:   "DAILY",
+					Amount:   50000000,
+					Delivery: "STANDARD",
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func(bs []Budget) {
+		_, err = s.Mutate(BudgetOperations{"REMOVE": bs})
+		if err != nil {
+			t.Error(err)
+		}
+	}(budgets)
+
+	foundBudgets, _, err := s.Get(
+		Selector{
+			Fields: []string{
+				"BudgetId",
+				"BudgetName",
+				"Period",
+				"Amount",
+				"DeliveryMethod",
+				"BudgetReferenceCount",
+				"IsBudgetExplicitlyShared",
+				"BudgetStatus",
+			},
+			Predicates: []Predicate{
+				{"Amount", "LESS_THAN_EQUALS", []string{"500000000"}},
+				{"BudgetStatus", "EQUALS", []string{"ENABLED"}},
+			},
+			Ordering: []OrderBy{
+				{"BudgetId", "ASCENDING"},
+				{"Amount", "ASCENDING"},
+			},
+			Paging: &Paging{
+				Offset: 0,
+				Limit:  100,
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("found %d budgets\n", len(foundBudgets))
+	for _, b := range budgets {
+		func(budget Budget) {
+			for _, foundBudget := range foundBudgets {
+				if foundBudget.Id == budget.Id {
+					return
+				}
+			}
+			t.Errorf("budget %d not found in \n%#v\n", budget.Id, foundBudgets)
+		}(b)
+	}
+}

--- a/v201702/campaign.go
+++ b/v201702/campaign.go
@@ -1,0 +1,391 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+// A campaignService holds the connection information for the
+// campaign service.
+type CampaignService struct {
+	Auth
+}
+
+// NewCampaignService creates a new campaignService
+func NewCampaignService(auth *Auth) *CampaignService {
+	return &CampaignService{Auth: *auth}
+}
+
+// ConversionOptimizerEligibility
+//
+// RejectionReasons can be any of
+//   "CAMPAIGN_IS_NOT_ACTIVE", "NOT_CPC_CAMPAIGN","CONVERSION_TRACKING_NOT_ENABLED",
+//   "NOT_ENOUGH_CONVERSIONS", "UNKNOWN"
+//
+type conversionOptimizerEligibility struct {
+	Eligible         bool     `xml:"eligible"`         // is eligible for optimization
+	RejectionReasons []string `xml:"rejectionReasons"` // reason for why campaign is
+	// not eligible for conversion optimization.
+}
+
+type FrequencyCap struct {
+	Impressions int64  `xml:"impressions"`
+	TimeUnit    string `xml:"timeUnit"`
+	Level       string `xml:"level,omitempty"`
+}
+
+type CampaignSetting struct {
+	XMLName xml.Name `xml:"settings"`
+	Type    string   `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+
+	// GeoTargetTypeSetting
+	PositiveGeoTargetType *string `xml:"positiveGeoTargetType,omitempty"`
+	NegativeGeoTargetType *string `xml:"negativeGeoTargetType,omitempty"`
+
+	// RealTimeBiddingSetting
+	OptIn *bool `xml:"optIn,omitempty"`
+
+	// DynamicSearchAdsSetting
+	DomainName   *string `xml:"domainName,omitempty"`
+	LanguageCode *string `xml:"langaugeCode,omitempty"`
+
+	// TrackingSetting
+	TrackingUrl *string `xml:"trackingUrl,omitempty"`
+}
+
+func NewDynamicSearchAdsSetting(domainName, languageCode string) CampaignSetting {
+	return CampaignSetting{
+		Type:         "DynamicSearchAdsSetting",
+		DomainName:   &domainName,
+		LanguageCode: &languageCode,
+	}
+}
+
+func NewGeoTargetTypeSetting(positiveGeoTargetType, negativeGeoTargetType string) CampaignSetting {
+	return CampaignSetting{
+		Type: "GeoTargetTypeSetting",
+		PositiveGeoTargetType: &positiveGeoTargetType,
+		NegativeGeoTargetType: &negativeGeoTargetType,
+	}
+}
+
+func NewRealTimeBiddingSetting(optIn bool) CampaignSetting {
+	return CampaignSetting{
+		Type:  "RealTimeBiddingSetting",
+		OptIn: &optIn,
+	}
+}
+
+func NewTrackingSetting(trackingUrl string) CampaignSetting {
+	return CampaignSetting{
+		Type:        "TrackingSetting",
+		TrackingUrl: &trackingUrl,
+	}
+}
+
+type NetworkSetting struct {
+	TargetGoogleSearch         bool `xml:"https://adwords.google.com/api/adwords/cm/v201702 targetGoogleSearch"`
+	TargetSearchNetwork        bool `xml:"https://adwords.google.com/api/adwords/cm/v201702 targetSearchNetwork"`
+	TargetContentNetwork       bool `xml:"https://adwords.google.com/api/adwords/cm/v201702 targetContentNetwork"`
+	TargetPartnerSearchNetwork bool `xml:"https://adwords.google.com/api/adwords/cm/v201702 targetPartnerSearchNetwork"`
+}
+
+type BiddingScheme struct {
+	Type               string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	EnhancedCpcEnabled bool   `xml:"enhancedCpcEnabled"`
+}
+
+type Bid struct {
+	Type         string  `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Amount       int64   `xml:"bid>microAmount"`
+	CpcBidSource *string `xml:"cpcBidSource"`
+	CpmBidSource *string `xml:"cpmBidSource"`
+}
+
+type BiddingStrategyConfiguration struct {
+	StrategyId     int64          `xml:"biddingStrategyId,omitempty"`
+	StrategyName   string         `xml:"biddingStrategyName,omitempty"`
+	StrategyType   string         `xml:"biddingStrategyType,omitempty"`
+	StrategySource string         `xml:"biddingStrategySource,omitempty"`
+	Scheme         *BiddingScheme `xml:"biddingScheme,omitempty"`
+	Bids           []Bid          `xml:"bids"`
+}
+
+type CustomParameter struct {
+	Key      string `xml:"key"`
+	Value    string `xml:"value"`
+	IsRemove bool   `xml:"isRemove"`
+}
+
+type CustomParameters struct {
+	CustomParameters []CustomParameter `xml:"parameters"`
+	DoReplace        bool              `xml:"doReplace"`
+}
+
+type Campaign struct {
+	Id                             int64                           `xml:"id,omitempty"`
+	Name                           string                          `xml:"name"`
+	Status                         string                          `xml:"status"`                  // Status: "ENABLED", "PAUSED", "REMOVED"
+	ServingStatus                  *string                         `xml:"servingStatus,omitempty"` // ServingStatus: "SERVING", "NONE", "ENDED", "PENDING", "SUSPENDED"
+	StartDate                      string                          `xml:"startDate"`
+	EndDate                        *string                         `xml:"endDate,omitempty"`
+	BudgetId                       int64                           `xml:"budget>budgetId"`
+	ConversionOptimizerEligibility *conversionOptimizerEligibility `xml:"conversionOptimizerEligibility"`
+	AdServingOptimizationStatus    string                          `xml:"adServingOptimizationStatus"`
+	FrequencyCap                   *FrequencyCap                   `xml:"frequencyCap"`
+	Settings                       []CampaignSetting               `xml:"settings"`
+	AdvertisingChannelType         string                          `xml:"advertisingChannelType,omitempty"`    // "UNKNOWN", "SEARCH", "DISPLAY", "SHOPPING"
+	AdvertisingChannelSubType      *string                         `xml:"advertisingChannelSubType,omitempty"` // "UNKNOWN", "SEARCH_MOBILE_APP", "DISPLAY_MOBILE_APP", "SEARCH_EXPRESS", "DISPLAY_EXPRESS"
+	NetworkSetting                 *NetworkSetting                 `xml:"networkSetting"`
+	Labels                         []Label                         `xml:"labels"`
+	BiddingStrategyConfiguration   *BiddingStrategyConfiguration   `xml:"biddingStrategyConfiguration"`
+	ForwardCompatibilityMap        *map[string]string              `xml:"forwardCompatibilityMap,omitempty"`
+	TrackingUrlTemplate            *string                         `xml:"trackingUrlTemplate"`
+	UrlCustomParameters            *CustomParameters               `xml:"urlCustomParameters"`
+	Errors                         []error                         `xml:"-"`
+}
+
+type CampaignOperations map[string][]Campaign
+
+type CampaignLabel struct {
+	CampaignId int64 `xml:"campaignId"`
+	LabelId    int64 `xml:"labelId"`
+}
+
+type CampaignLabelOperations map[string][]CampaignLabel
+
+// Get returns an array of Campaign's and the total number of campaign's matching
+// the selector.
+//
+// Example
+//
+//   campaigns, totalCount, err := campaignService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//         "Status",
+//         "AdGroupCreativeApprovalStatus",
+//         "AdGroupAdDisapprovalReasons",
+//         "AdGroupAdTrademarkDisapproved",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"AdGroupId", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "Id", "Name", "Status", "ServingStatus", "StartDate", "EndDate", "AdServingOptimizationStatus",
+//   "Settings", "AdvertisingChannelType", "AdvertisingChannelSubType", "Labels", "TrackingUrlTemplate",
+//   "UrlCustomParameters"
+//
+// filterable fields are
+//   "Id", "Name", "Status", "ServingStatus", "StartDate", "EndDate", "AdvertisingChannelType",
+//   "AdvertisingChannelSubType", "Labels", "TrackingUrlTemplate"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#get
+//
+func (s *CampaignService) Get(selector Selector) (campaigns []Campaign, totalCount int64, err error) {
+	// The default namespace, "", will break in 1.5 with the addition of
+	// custom namespace support.  Hence, we have to ensure that the baseUrl is
+	// set again as the proper namespace for the service/serviceSelector element
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+
+	respBody, err := s.Auth.request(
+		campaignServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+	getResp := struct {
+		Size      int64      `xml:"rval>totalNumEntries"`
+		Campaigns []Campaign `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+	return getResp.Campaigns, getResp.Size, err
+}
+
+// Mutate allows you to add and modify campaigns, returning the
+// campaigns.  Note that the "REMOVE" operator is not supported.
+// To remove a campaign set its Status to "REMOVED".
+//
+// Example
+//
+//  campaignNeedingRemoval.Status = "REMOVED"
+//  ads, err := campaignService.Mutate(
+//    gads.CampaignOperations{
+//      "ADD": {
+//        gads.Campaign{
+//          Name: "my campaign name",
+//          Status: "PAUSED",
+//          StartDate: time.Now().Format("20060102"),
+//          BudgetId: 321543214,
+//          AdServingOptimizationStatus: "ROTATE_INDEFINITELY",
+//          Settings: []gads.CampaignSetting{
+//            gads.NewRealTimeBiddingSetting(true),
+//          },
+//          AdvertisingChannelType: "SEARCH",
+//          BiddingStrategyConfiguration: &gads.BiddingStrategyConfiguration{
+//            StrategyType: "MANUAL_CPC",
+//          },
+//        },
+//        campaignNeedingRemoval,
+//      },
+//      "SET": {
+//        modifiedCampaign,
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#mutate
+//
+func (s *CampaignService) Mutate(campaignOperations CampaignOperations) (campaigns []Campaign, err error) {
+	type campaignOperation struct {
+		Action   string   `xml:"operator"`
+		Campaign Campaign `xml:"operand"`
+	}
+	operations := []campaignOperation{}
+	for action, campaigns := range campaignOperations {
+		for _, campaign := range campaigns {
+			operations = append(operations,
+				campaignOperation{
+					Action:   action,
+					Campaign: campaign,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []campaignOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(campaignServiceUrl, "mutate", mutation)
+	if err != nil {
+		return campaigns, err
+	}
+	mutateResp := struct {
+		Campaigns []Campaign `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return campaigns, err
+	}
+
+	return mutateResp.Campaigns, err
+}
+
+// Mutate allows you to add and removes labels from campaigns.
+//
+// Example
+//
+//  cls, err := campaignService.MutateLabel(
+//    gads.CampaignOperations{
+//      "ADD": {
+//        gads.CampaignLabel{CampaignId: 3200, LabelId: 5353},
+//        gads.CampaignLabel{CampaignId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.CampaignLabel{CampaignId: 3653, LabelId: 5653},
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#mutateLabel
+//
+func (s *CampaignService) MutateLabel(campaignLabelOperations CampaignLabelOperations) (campaignLabels []CampaignLabel, err error) {
+	type campaignLabelOperation struct {
+		Action        string        `xml:"operator"`
+		CampaignLabel CampaignLabel `xml:"operand"`
+	}
+	operations := []campaignLabelOperation{}
+	for action, campaignLabels := range campaignLabelOperations {
+		for _, campaignLabel := range campaignLabels {
+			operations = append(operations,
+				campaignLabelOperation{
+					Action:        action,
+					CampaignLabel: campaignLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []campaignLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(campaignServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return campaignLabels, err
+	}
+	mutateResp := struct {
+		CampaignLabels []CampaignLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return campaignLabels, err
+	}
+
+	return mutateResp.CampaignLabels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#query
+//
+func (s *CampaignService) Query(query string) (campaigns []Campaign, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		campaignServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+
+	getResp := struct {
+		Size      int64      `xml:"rval>totalNumEntries"`
+		Campaigns []Campaign `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+	return getResp.Campaigns, getResp.Size, err
+}

--- a/v201702/campaign_criterion.go
+++ b/v201702/campaign_criterion.go
@@ -1,0 +1,266 @@
+package v201702
+
+import "encoding/xml"
+
+type CampaignCriterionService struct {
+	Auth
+}
+
+func NewCampaignCriterionService(auth *Auth) *CampaignCriterionService {
+	return &CampaignCriterionService{Auth: *auth}
+}
+
+type CampaignCriterion struct {
+	CampaignId  int64     `xml:"campaignId"`
+	IsNegative  bool      `xml:"isNegative,omitempty"`
+	Criterion   Criterion `xml:"criterion"`
+	BidModifier *float64  `xml:"bidModifier,omitempty"`
+	Errors      []error   `xml:"-"`
+}
+
+func (cc CampaignCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	isNegative := false
+	//fmt.Printf("processing -> %#v\n",ncc)
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"CampaignCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&cc.CampaignId, xml.StartElement{Name: xml.Name{"", "campaignId"}})
+	e.EncodeElement(&isNegative, xml.StartElement{Name: xml.Name{"", "isNegative"}})
+	if err := criterionMarshalXML(cc.Criterion, e); err != nil {
+		return err
+	}
+	if cc.BidModifier != nil {
+		e.EncodeElement(&cc.BidModifier, xml.StartElement{Name: xml.Name{"", "bidModifier"}})
+	}
+
+	e.EncodeToken(start.End())
+	return nil
+}
+
+type NegativeCampaignCriterion struct {
+	CampaignId  int64     `xml:"campaignId"`
+	IsNegative  bool      `xml:"isNegative,omitempty"`
+	Criterion   Criterion `xml:"criterion"`
+	BidModifier *float64  `xml:"bidModifier,omitempty"`
+	Errors      []error   `xml:"-"`
+}
+
+type CampaignCriterions []interface{}
+type CampaignCriterionOperations map[string]CampaignCriterions
+
+func (ncc NegativeCampaignCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	isNegative := true
+	//fmt.Printf("processing -> %#v\n",ncc)
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"NegativeCampaignCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&ncc.CampaignId, xml.StartElement{Name: xml.Name{"", "campaignId"}})
+	e.EncodeElement(&isNegative, xml.StartElement{Name: xml.Name{"", "isNegative"}})
+	criterionMarshalXML(ncc.Criterion, e)
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (ccs *CampaignCriterions) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	cc := NegativeCampaignCriterion{}
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			switch start.Name.Local {
+			case "campaignId":
+				if err := dec.DecodeElement(&cc.CampaignId, &start); err != nil {
+					return err
+				}
+			case "criterion":
+				criterion, err := criterionUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				cc.Criterion = criterion
+			case "bidModifier":
+				if err := dec.DecodeElement(&cc.BidModifier, &start); err != nil {
+					return err
+				}
+			case "isNegative":
+				if err := dec.DecodeElement(&cc.IsNegative, &start); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	*ccs = append(*ccs, cc)
+	return nil
+}
+
+/*
+func NewNegativeCampaignCriterion(campaignId int64, bidModifier float64, criterion interface{}) CampaignCriterion {
+  return CampaignCriterion{
+    CampaignId: campaignId,
+    Criterion: criterion,
+    BidModifier: bidModifier
+  }
+  switch c := criterion.(type) {
+  case AdScheduleCriterion:
+  case AgeRangeCriterion:
+  case ContentLabelCriterion:
+  case GenderCriterion:
+  case KeywordCriterion:
+  case LanguageCriterion:
+  case LocationCriterion:
+  case MobileAppCategoryCriterion:
+  case MobileApplicationCriterion:
+  case MobileDeviceCriterion:
+  case OperatingSystemVersionCriterion:
+  case PlacementCriterion:
+  case PlatformCriterion:
+  case ProductCriterion:
+  case ProximityCriterion:
+  case UserInterestCriterion:
+    cc.Criterion = criterion
+  case UserListCriterion:
+    cc.Criterion = criterion
+  case VerticalCriterion:
+  }
+}
+*/
+
+func (s *CampaignCriterionService) Get(selector Selector) (campaignCriterions CampaignCriterions, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		campaignCriterionServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+	getResp := struct {
+		Size               int64              `xml:"rval>totalNumEntries"`
+		CampaignCriterions CampaignCriterions `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+	return getResp.CampaignCriterions, getResp.Size, err
+}
+
+func (s *CampaignCriterionService) Mutate(campaignCriterionOperations CampaignCriterionOperations) (campaignCriterions CampaignCriterions, err error) {
+	type campaignCriterionOperation struct {
+		Action            string      `xml:"operator"`
+		CampaignCriterion interface{} `xml:"operand"`
+	}
+	operations := []campaignCriterionOperation{}
+	for action, campaignCriterions := range campaignCriterionOperations {
+		for _, campaignCriterion := range campaignCriterions {
+			operations = append(operations,
+				campaignCriterionOperation{
+					Action:            action,
+					CampaignCriterion: campaignCriterion,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []campaignCriterionOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(campaignCriterionServiceUrl, "mutate", mutation)
+	if err != nil {
+		/*
+			    switch t := err.(type) {
+			    case *ErrorsType:
+				    for action, campaignCriterions := range campaignCriterionOperations {
+					    for _, campaignCriterion := range campaignCriterions {
+			          campaignCriterions = append(campaignCriterions,campaignCriterion)
+			        }
+			      }
+			      for _, aef := range t.ApiExceptionFaults {
+			        for _,e := range aef.Errors {
+			          switch et := e.(type) {
+			          case CriterionError:
+			            offset, err := strconv.ParseInt(strings.Trim(et.FieldPath,"abcdefghijklmnop.]["),10,64)
+			            if err != nil {
+			              return CampaignCriterions{}, err
+			            }
+			            cc := campaignCriterions[offset]
+			            switch c := cc.(type) {
+			            case CampaignCriterion:
+			              CampaignCriterion(campaignCriterions[offset]).Errors = append(campaignCriterions[offset].(CampaignCriterion).Errors,fmt.Errorf(et.Reason))
+			            case NegativeCampaignCriterion:
+			              NegativeCampaignCriterion(campaignCriterions[offset]).Errors = append(NegativeCampaignCriterion(campaignCriterions[offset].Errors),fmt.Errorf(et.Reason))
+			            }
+			          }
+			        }
+			      }
+			    default:
+		*/
+		return campaignCriterions, err
+		//}
+	}
+	mutateResp := struct {
+		CampaignCriterions CampaignCriterions `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return campaignCriterions, err
+	}
+	return mutateResp.CampaignCriterions, err
+}
+
+func (s *CampaignCriterionService) Query(query string) (campaignCriterions CampaignCriterions, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		campaignCriterionServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+
+	getResp := struct {
+		Size               int64              `xml:"rval>totalNumEntries"`
+		CampaignCriterions CampaignCriterions `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+	return getResp.CampaignCriterions, getResp.Size, err
+}

--- a/v201702/campaign_criterion_test.go
+++ b/v201702/campaign_criterion_test.go
@@ -1,0 +1,41 @@
+package v201702
+
+import (
+	"testing"
+	//  "encoding/xml"
+)
+
+func testCampaignCriterionService(t *testing.T) (service *CampaignCriterionService) {
+	return &CampaignCriterionService{Auth: testAuthSetup(t)}
+}
+
+func TestCampaignCriterion(t *testing.T) {
+	campaign, cleanupCampaign := testCampaign(t)
+	defer cleanupCampaign()
+
+	ccs := testCampaignCriterionService(t)
+	campaignCriterions, err := ccs.Mutate(
+		CampaignCriterionOperations{
+			"ADD": {
+				CampaignCriterion{CampaignId: campaign.Id, Criterion: AdScheduleCriterion{DayOfWeek: "MONDAY", StartHour: "10", StartMinute: "ZERO", EndHour: "13", EndMinute: "ZERO"}},
+				CampaignCriterion{CampaignId: campaign.Id, Criterion: Location{Id: 2392}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//t.Fatalf("%#v\n",campaignCriterions)
+
+	defer func() {
+		_, err = ccs.Mutate(CampaignCriterionOperations{"REMOVE": campaignCriterions})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+}

--- a/v201702/campaign_extension.go
+++ b/v201702/campaign_extension.go
@@ -1,0 +1,95 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type CampaignExtensionSettingService struct {
+	Auth
+}
+
+func NewCampaignExtensionService(auth *Auth) *CampaignExtensionSettingService {
+	return &CampaignExtensionSettingService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/CampaignExtensionSettingService.CampaignExtensionSetting
+// A CampaignExtensionSetting is used to add or modify extensions being served for the specified campaign.
+type CampaignExtensionSetting struct {
+	CampaignId       int64            `xml:"https://adwords.google.com/api/adwords/cm/v201702 campaignId,omitempty"`
+	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201702 extensionType,omitempty"`
+	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201702 extensionSetting,omitempty"`
+}
+
+type CampaignExtensionSettingOperations map[string][]CampaignExtensionSetting
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/CampaignExtensionSettingService#query
+func (s *CampaignExtensionSettingService) Query(query string) (settings []CampaignExtensionSetting, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		campaignExtensionSettingUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	getResp := struct {
+		Size     int64                      `xml:"rval>totalNumEntries"`
+		Settings []CampaignExtensionSetting `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal(respBody, &getResp)
+	if err != nil {
+		return
+	}
+	return getResp.Settings, getResp.Size, err
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/CampaignExtensionSettingService#mutate
+func (s *CampaignExtensionSettingService) Mutate(settingsOperations CampaignExtensionSettingOperations) (settings []CampaignExtensionSetting, err error) {
+	type settingOperations struct {
+		Action  string                   `xml:"operator"`
+		Setting CampaignExtensionSetting `xml:"operand"`
+	}
+	operations := []settingOperations{}
+	for action, settings := range settingsOperations {
+		for _, setting := range settings {
+			operations = append(operations,
+				settingOperations{
+					Action:  action,
+					Setting: setting,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []settingOperations `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+
+	respBody, err := s.Auth.request(campaignExtensionSettingUrl, "mutate", mutation)
+	if err != nil {
+		return settings, err
+	}
+	mutateResp := struct {
+		Settings []CampaignExtensionSetting `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal(respBody, &mutateResp)
+	if err != nil {
+		return settings, err
+	}
+
+	return mutateResp.Settings, err
+}

--- a/v201702/campaign_feed.go
+++ b/v201702/campaign_feed.go
@@ -1,0 +1,9 @@
+package v201702
+
+type CampaignFeedService struct {
+	Auth
+}
+
+func NewCampaignFeedService(auth *Auth) *CampaignFeedService {
+	return &CampaignFeedService{Auth: *auth}
+}

--- a/v201702/campaign_management_test.go
+++ b/v201702/campaign_management_test.go
@@ -1,0 +1,3 @@
+package v201702
+
+import ()

--- a/v201702/campaign_shared_set.go
+++ b/v201702/campaign_shared_set.go
@@ -1,0 +1,9 @@
+package v201702
+
+type CampaignSharedSetService struct {
+	Auth
+}
+
+func NewCampaignSharedSetService(auth *Auth) *CampaignSharedSetService {
+	return &CampaignSharedSetService{Auth: *auth}
+}

--- a/v201702/campaign_test.go
+++ b/v201702/campaign_test.go
@@ -1,0 +1,156 @@
+package v201702
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func testCampaignService(t *testing.T) (service *CampaignService) {
+	return &CampaignService{Auth: testAuthSetup(t)}
+}
+
+func testCampaign(t *testing.T) (Campaign, func()) {
+	budget, cleanupBudget := testBudget(t)
+	cs := testCampaignService(t)
+	campaigns, err := cs.Mutate(
+		CampaignOperations{
+			"ADD": {
+				Campaign{
+					Name:                        "test campaign " + rand_str(10),
+					Status:                      "PAUSED",
+					StartDate:                   time.Now().Format("20060102"),
+					BudgetId:                    budget.Id,
+					AdServingOptimizationStatus: "ROTATE_INDEFINITELY",
+					Settings: []CampaignSetting{
+						NewRealTimeBiddingSetting(true),
+					},
+					AdvertisingChannelType: "SEARCH",
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupCampaign := func() {
+		campaigns[0].Status = "REMOVED"
+		_, err = cs.Mutate(CampaignOperations{"SET": campaigns})
+		if err != nil {
+			t.Error(err)
+		}
+		cleanupBudget()
+	}
+	return campaigns[0], cleanupCampaign
+}
+
+func TestCampaign(t *testing.T) {
+	budget, cleanupBudget := testBudget(t)
+	defer cleanupBudget()
+
+	cs := testCampaignService(t)
+	campaigns, err := cs.Mutate(
+		CampaignOperations{
+			"ADD": {
+				Campaign{
+					Name:                        "test campaign " + rand_str(10),
+					Status:                      "PAUSED",
+					StartDate:                   time.Now().Format("20060102"),
+					BudgetId:                    budget.Id,
+					AdServingOptimizationStatus: "ROTATE_INDEFINITELY",
+					Settings: []CampaignSetting{
+						NewRealTimeBiddingSetting(true),
+					},
+					AdvertisingChannelType: "SEARCH",
+					NetworkSetting: &NetworkSetting{
+						TargetGoogleSearch:         true,
+						TargetSearchNetwork:        true,
+						TargetContentNetwork:       false,
+						TargetPartnerSearchNetwork: false,
+					},
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func(campaigns []Campaign) {
+		campaigns[0].Status = "REMOVED"
+		_, err = cs.Mutate(CampaignOperations{"SET": campaigns})
+		if err != nil {
+			t.Error(err)
+		}
+	}(campaigns)
+
+	label, labelCleanup := testLabel(t)
+	defer labelCleanup()
+
+	campaignLabels, err := cs.MutateLabel(
+		CampaignLabelOperations{
+			"ADD": {
+				CampaignLabel{CampaignId: campaigns[0].Id, LabelId: label.Id},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		campaignLabels, err = cs.MutateLabel(CampaignLabelOperations{"REMOVE": campaignLabels})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	foundCampaigns, _, err := cs.Get(
+		Selector{
+			Fields: []string{
+				"Id",
+				"Name",
+				"Status",
+				"ServingStatus",
+				"StartDate",
+				"EndDate",
+				"AdServingOptimizationStatus",
+				"Settings",
+				"Labels",
+			},
+			Predicates: []Predicate{
+				{"Status", "EQUALS", []string{"PAUSED"}},
+			},
+			Ordering: []OrderBy{
+				{"Id", "ASCENDING"},
+			},
+			Paging: &Paging{
+				Offset: 0,
+				Limit:  100,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("found %d campaigns\n", len(foundCampaigns))
+	for _, c := range campaigns {
+		func(campaign Campaign) {
+			for _, foundCampaign := range foundCampaigns {
+				if foundCampaign.Id == campaign.Id {
+					fmt.Printf("%#v", foundCampaign)
+					return
+				}
+			}
+			t.Errorf("campaign %d not found in \n%#v\n", campaign.Id, foundCampaigns)
+		}(c)
+	}
+
+}

--- a/v201702/cli/adgroups_awql.go
+++ b/v201702/cli/adgroups_awql.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// show all Campaigns
+	cs := gads.NewAdGroupService(&config.Auth)
+	fmt.Printf("AdGroups\n")
+
+	foundAdGroups, totalCount, err := cs.Query("SELECT AdGroupId, Name, Status WHERE CampaignId = '123'")
+	fmt.Println(totalCount)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, adGroup := range foundAdGroups {
+		adGroupJSON, _ := json.MarshalIndent(adGroup, "", "  ")
+		fmt.Printf("%s\n", adGroupJSON)
+	}
+
+}

--- a/v201702/cli/batch_job.go
+++ b/v201702/cli/batch_job.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+	"strconv"
+	"time"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// Your campaign ID should go here
+var campaignId int64 = 1234567890
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Batch Job
+	bs := gads.NewBatchJobService(&config.Auth)
+
+	/*ago := gads.AdGroupCriterionOperations{
+	"SET":	gads.AdGroupCriterions {
+				gads.BiddableAdGroupCriterion{
+					AdGroupId: 11400713462,
+					Criterion: gads.KeywordCriterion{
+						Id: 47652524966,
+					},
+					BiddingStrategyConfiguration: &gads.BiddingStrategyConfiguration{
+						Bids: []gads.Bid{
+							gads.Bid{
+								Type:   "CpcBid",
+								Amount: 5372200,
+							},
+						},
+					},
+					UrlCustomParameters: gads.CustomParameters{
+						CustomParameters: []gads.CustomParameter{
+							gads.CustomParameter{
+								Key:      "foo",
+								Value:    "bar",
+								IsRemove: false,
+							},
+						},
+						DoReplace: false,
+					},
+				},
+				gads.BiddableAdGroupCriterion{
+					AdGroupId: 11400713462,
+					Criterion: gads.KeywordCriterion{
+						Id: 47652524366,
+					},
+					BiddingStrategyConfiguration: &gads.BiddingStrategyConfiguration{
+						Bids: []gads.Bid{
+							gads.Bid{
+								Type:   "CpcBid",
+								Amount: 5372200,
+							},
+						},
+					},
+					UrlCustomParameters: gads.CustomParameters{
+						CustomParameters: []gads.CustomParameter{
+							gads.CustomParameter{
+								Key:      "foo",
+								Value:    "bar",
+								IsRemove: false,
+							},
+						},
+						DoReplace: false,
+					},
+				},
+			},
+	}*/
+	// Creating AdGroups
+	ago := gads.AdGroupOperations{
+		"ADD": {},
+	}
+
+	// stress test uploading
+	var adGroupNum int = 10000
+
+	for i := 0; i < adGroupNum; i++ {
+		ago["ADD"] = append(ago["ADD"], gads.AdGroup{
+			Name:       "test ad group " + rand_str(10),
+			Status:     "PAUSED",
+			CampaignId: campaignId,
+		})
+	}
+
+	var operations []interface{}
+	operations = append(operations, ago)
+
+	bjo := gads.BatchJobOperations{
+		BatchJobOperations: []gads.BatchJobOperation{
+			gads.BatchJobOperation{
+				Operator: "ADD",
+				Operand:  gads.BatchJob{},
+			},
+		},
+	}
+
+	if resp, err := bs.Mutate(bjo); err == nil {
+
+		bjh := gads.NewBatchJobHelper(&config.Auth)
+		err = bjh.UploadBatchJobOperations(operations, *resp[0].UploadUrl)
+
+		if err != nil {
+			panic(err)
+		}
+
+		jobId := resp[0].Id
+		batchJobs := gads.BatchJobPage{}
+
+		// loop
+		for {
+			// recheck every 5 seconds
+			time.Sleep(5 * time.Second)
+			selector := gads.Selector{
+				Fields: []string{
+					"Id",
+					"Status",
+					"DownloadUrl",
+					"ProcessingErrors",
+					"ProgressStats",
+				},
+				Predicates: []gads.Predicate{
+					{"Id", "EQUALS", []string{strconv.FormatInt(jobId, 10)}},
+				},
+			}
+
+			// more than likely you'll want to have some logic to loop through these if you have multiple batch jobs, but since only one we just want to grab the first one
+			batchJobs, err = bs.Get(selector)
+
+			if err != nil {
+				panic(err)
+			}
+
+			if batchJobs.BatchJobs[0].Status == "DONE" {
+				break
+			} else if batchJobs.BatchJobs[0].Status == "CANCELED" {
+				panic("Job was canceled")
+			}
+		}
+
+		if batchJobs.BatchJobs[0].DownloadUrl.Url != "" {
+			// get the job
+			mutateResult, err := bjh.DownloadBatchJob(*batchJobs.BatchJobs[0].DownloadUrl)
+
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Println(mutateResult)
+			jsonResult, _ := json.Marshal(mutateResult)
+
+			fmt.Println(string(jsonResult))
+		}
+	} else {
+		// handle err
+		panic(err)
+	}
+
+}
+
+func rand_str(str_size int) string {
+	alphanum := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}

--- a/v201702/cli/bid_landscape.go
+++ b/v201702/cli/bid_landscape.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// Your IDs should go here
+var campaignId string = "1234567890"
+var adGroupId string = "1234567890"
+var criterionId string = "1234567890"
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	service := gads.NewDataService(&config.Auth)
+
+	// Test GetAdGroupBidLandscape
+
+	adGroupBidLandscape, _, err := service.GetAdGroupBidLandscape(
+		gads.Selector{
+			Fields: []string{
+				"AdGroupId",
+				"Bid",
+				"CampaignId",
+				"LocalClicks",
+				"LocalCost",
+				"LocalImpressions",
+				"PromotedImpressions",
+				"StartDate",
+				"EndDate",
+			},
+			Predicates: []gads.Predicate{
+				{"AdGroupId", "EQUALS", []string{adGroupId}},
+			},
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range adGroupBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test GetAdGroupBidLandscape
+
+	// Test QueryAdGroupBidLandscape
+
+	foundBidLandscape, _, err := service.QueryAdGroupBidLandscape(fmt.Sprintf("SELECT AdGroupId, Bid, CampaignId, LocalClicks, LocalCost, LocalImpressions WHERE AdGroupId = '%v'", adGroupId))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range foundBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test QueryAdGroupBidLandscape
+
+	// Test GetCriterionBidLandscape
+
+	criterionBidLandscape, _, err := service.GetCriterionBidLandscape(
+		gads.Selector{
+			Fields: []string{
+				"AdGroupId",
+				"Bid",
+				"CampaignId",
+				"CriterionId",
+				"LocalClicks",
+				"LocalCost",
+				"LocalImpressions",
+				"PromotedImpressions",
+				"StartDate",
+				"EndDate",
+			},
+			Predicates: []gads.Predicate{
+				{"CriterionId", "EQUALS", []string{criterionId}},
+				{"AdGroupId", "EQUALS", []string{adGroupId}},
+			},
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range criterionBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test GetCriterionBidLandscape
+
+	// Test QueryCriterionBidLandscape
+
+	queryCriterionBidLandscape, _, err := service.QueryCriterionBidLandscape(fmt.Sprintf("SELECT AdGroupId, Bid, CampaignId, CriterionId, LocalClicks, LocalCost, LocalImpressions WHERE AdGroupId = '%v' AND CriterionId = '%v'", adGroupId, criterionId))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range queryCriterionBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test QueryCriterionBidLandscape
+
+}

--- a/v201702/cli/campaign_criterion.go
+++ b/v201702/cli/campaign_criterion.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cs := gads.NewCampaignCriterionService(&config.Auth)
+
+	//bidmodifier := float64(2)
+	//var bidmodifier float64
+	//bidmodifier = 1.04
+
+	campaignCriterions := gads.CampaignCriterions{
+		gads.NegativeCampaignCriterion{
+			CampaignId: 123456789,
+			Criterion: gads.Location{
+				Id: 21168,
+			},
+		},
+		gads.CampaignCriterion{
+			CampaignId: 123456789,
+			Criterion: gads.Location{
+				Id: 21167,
+			},
+		},
+	}
+
+	criterions, err := cs.Mutate(
+		gads.CampaignCriterionOperations{
+			"ADD": campaignCriterions,
+		},
+	)
+
+	fmt.Println(criterions)
+	criterionJSON, _ := json.MarshalIndent(criterions, "", "  ")
+	fmt.Printf("%s\n", criterionJSON)
+
+	// show all Location Criterion
+	fmt.Printf("Campaign Criterion\n")
+	foundCriterions, totalCount, err := cs.Query("SELECT CampaignId,IsNegative,BidModifier,CriteriaType,Id,LocationName,DisplayType,ParentLocations WHERE CampaignId = '211793582' AND CriteriaType IN ['LOCATION']")
+	fmt.Println(totalCount)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, criterion := range foundCriterions {
+		criterionJSON, _ := json.MarshalIndent(criterion, "", "  ")
+		fmt.Printf("%s\n", criterionJSON)
+	}
+
+}

--- a/v201702/cli/campaigns.go
+++ b/v201702/cli/campaigns.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/colinmutter/gads/v201702"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+func main() {
+	config, err := gads.NewCredentials(oauth2.NoContext)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var pageSize int64 = 500
+	var offset int64
+
+	// show all Campaigns
+	cs := gads.NewCampaignService(&config.Auth)
+	paging := gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nCampaigns\n")
+	for {
+		foundCampaigns, totalCount, err := cs.Get(
+			gads.Selector{
+				Fields: []string{
+					"Id",
+					"Name",
+					"Status",
+					"ServingStatus",
+					"StartDate",
+					"EndDate",
+					"AdServingOptimizationStatus",
+					"Settings",
+					"AdvertisingChannelType",
+					"AdvertisingChannelSubType",
+					"Labels",
+					"TrackingUrlTemplate",
+					"UrlCustomParameters",
+				},
+				Predicates: []gads.Predicate{
+					{"Status", "EQUALS", []string{"PAUSED"}},
+				},
+				Ordering: []gads.OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, campaign := range foundCampaigns {
+			campaignJson, _ := json.MarshalIndent(campaign, "", "  ")
+			fmt.Printf("%s\n", campaignJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+}

--- a/v201702/cli/cli.go
+++ b/v201702/cli/cli.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+func main() {
+	config, err := gads.NewCredentials(oauth2.NoContext)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bs := gads.NewBudgetService(&config.Auth)
+
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nBudgets\n")
+	for {
+		foundBudgets, totalCount, err := bs.Get(gads.Selector{
+			Fields: []string{
+				"BudgetId",
+				"BudgetName",
+				"Period",
+				"Amount",
+				"DeliveryMethod",
+				"BudgetReferenceCount",
+				"IsBudgetExplicitlyShared",
+				"BudgetStatus",
+			},
+			Paging: &paging,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, budget := range foundBudgets {
+			budgetJson, _ := json.MarshalIndent(budget, "", "  ")
+			fmt.Printf("  %s\n", string(budgetJson))
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+	// show all Campaigns
+	cs := gads.NewCampaignService(&config.Auth)
+	offset = 0
+	paging = gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nCampaigns\n")
+	for {
+		foundCampaigns, totalCount, err := cs.Get(
+			gads.Selector{
+				Fields: []string{
+					"Id",
+					"BudgetId",
+					"Name",
+					"Status",
+					"ServingStatus",
+					"StartDate",
+					"EndDate",
+					"AdServingOptimizationStatus",
+					"Settings",
+					"AdvertisingChannelType",
+					"AdvertisingChannelSubType",
+					"Labels",
+					"TrackingUrlTemplate",
+					"UrlCustomParameters",
+				},
+				Predicates: []gads.Predicate{
+					{"Status", "EQUALS", []string{"PAUSED"}},
+				},
+				Ordering: []gads.OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, campaign := range foundCampaigns {
+			campaignJson, _ := json.MarshalIndent(campaign, "", "  ")
+			fmt.Printf("%s\n", campaignJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+	ags := gads.NewAdGroupService(&config.Auth)
+	offset = 0
+	paging = gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nAdGroups\n")
+	for {
+		foundAdGroups, totalCount, err := ags.Get(
+			gads.Selector{
+				Fields: []string{
+					"Id",
+					"CampaignId",
+					"CampaignName",
+					"Name",
+					"Status",
+					"Settings",
+					"ContentBidCriterionTypeGroup",
+				},
+				Predicates: []gads.Predicate{
+					{"Status", "EQUALS", []string{"PAUSED"}},
+				},
+				Ordering: []gads.OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, adGroup := range foundAdGroups {
+			adGroupJson, _ := json.MarshalIndent(adGroup, "", "  ")
+			fmt.Printf("%#v\n", adGroupJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+	agas := gads.NewAdGroupAdService(&config.Auth)
+	offset = 0
+	paging = gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nAds\n")
+	for {
+		foundAds, totalCount, err := agas.Get(
+			gads.Selector{
+				Fields: []string{
+					"AdGroupId",
+					"Status",
+					"AdGroupCreativeApprovalStatus",
+					"AdGroupAdDisapprovalReasons",
+					"AdGroupAdTrademarkDisapproved",
+				},
+				Ordering: []gads.OrderBy{
+					{"AdGroupId", "ASCENDING"},
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, ad := range foundAds {
+			adJson, _ := json.MarshalIndent(ad, "", "  ")
+			fmt.Printf("%s\n", adJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+}

--- a/v201702/cli/crm_based_user_list.go
+++ b/v201702/cli/crm_based_user_list.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// Your campaign ID should go here
+var campaignId int64 = 1234567890
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// User List Service
+	auls := gads.NewAdwordsUserListService(&config.Auth)
+
+	crmList := gads.NewCrmBasedUserList("Test List", "Just a list to test with", 0, "http://mytest.com/optout")
+
+	ops := gads.UserListOperations{
+		Operations: []gads.Operation{
+			gads.Operation{
+				Operator: "ADD",
+				Operand:  crmList,
+			},
+		},
+	}
+
+	resp, err := auls.Mutate(ops)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(resp[0].Id)
+
+	mmo := gads.NewMutateMembersOperand()
+	mmo.UserListId = resp[0].Id
+
+	var members []string
+	members = append(members, "brian@test.com")
+	members = append(members, "test@test.com")
+
+	mmo.Members = members
+
+	mutateMembersOperations := gads.MutateMembersOperations{
+		Operations: []gads.Operation{
+			gads.Operation{
+				Operator: "ADD",
+				Operand:  mmo,
+			},
+		},
+	}
+
+	lists, err := auls.MutateMembers(mutateMembersOperations)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(lists)
+}

--- a/v201702/cli/customer_service.go
+++ b/v201702/cli/customer_service.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cs := gads.NewCustomerService(&config.Auth)
+
+	customers, err := cs.GetCustomers()
+
+	fmt.Println(customers)
+	customersJSON, err := json.MarshalIndent(customers, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", customersJSON)
+
+}

--- a/v201702/cli/expanded_text_ad.go
+++ b/v201702/cli/expanded_text_ad.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	aga := gads.NewAdGroupAdService(&config.Auth)
+
+	ads, err := aga.Mutate(
+		gads.AdGroupAdOperations{
+			"ADD": {
+				gads.ExpandedTextAd{
+					AdGroupId:     1234567890,
+					FinalUrls:     []string{"https://classdo.com/en"},
+					Path1:         "path1",
+					Path2:         "path2",
+					HeadlinePart1: "test headline",
+					HeadlinePart2: "test headline2",
+					Description:   "test line one",
+				},
+			},
+		},
+	)
+
+	fmt.Println(ads)
+	adsJSON, err := json.MarshalIndent(ads, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", adsJSON)
+
+}

--- a/v201702/cli/flush.go
+++ b/v201702/cli/flush.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"crypto/rand"
+	"github.com/colinmutter/gads/v201702"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+func rand_str(str_size int) string {
+	alphanum := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}
+
+func main() {
+	config, err := gads.NewCredentials(oauth2.NoContext)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ags := gads.NewAdGroupService(config.Auth)
+	foundAdGroups, err := ags.Get(
+		gads.Selector{
+			Fields: []string{
+				"Id",
+				"CampaignId",
+				"CampaignName",
+				"Name",
+				"Status",
+				"Settings",
+				"ContentBidCriterionTypeGroup",
+			},
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for idx, _ := range foundAdGroups {
+		foundAdGroups[idx].Status = "REMOVED"
+		foundAdGroups[idx].Name = rand_str(20)
+	}
+
+	_, err = ags.Mutate(gads.AdGroupOperations{"SET": foundAdGroups})
+
+	// Remove all Campaigns
+	cs := gads.NewCampaignService(config.Auth)
+	foundCampaigns, err := cs.Get(
+		gads.Selector{
+			Fields: []string{
+				"Id",
+				"BudgetId",
+				"Name",
+				"Status",
+				"ServingStatus",
+				"StartDate",
+				"EndDate",
+				"AdServingOptimizationStatus",
+				"Settings",
+			},
+			Ordering: []gads.OrderBy{
+				{"Id", "ASCENDING"},
+			},
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	for idx, _ := range foundCampaigns {
+		foundCampaigns[idx].Status = "REMOVED"
+		foundCampaigns[idx].Name = rand_str(20)
+	}
+	_, err = cs.Mutate(gads.CampaignOperations{"SET": foundCampaigns})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Remove all budgets
+	bs := gads.NewBudgetService(config.Auth)
+	foundBudgets, err := bs.Get(gads.Selector{Fields: []string{"BudgetId", "BudgetName", "Period", "Amount", "DeliveryMethod"}})
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = bs.Mutate(gads.BudgetOperations{"REMOVE": foundBudgets})
+	if err != nil {
+		log.Printf("%#v\n", err)
+		log.Fatal(err)
+	}
+}

--- a/v201702/cli/keywords_awql.go
+++ b/v201702/cli/keywords_awql.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// show all Keywords
+	cs := gads.NewAdGroupCriterionService(&config.Auth)
+	fmt.Printf("Keywords\n")
+	foundKeywords, totalCount, err := cs.Query("SELECT Id, KeywordText, KeywordMatchType WHERE AdGroupId = '123'")
+	fmt.Println(totalCount)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, keyword := range foundKeywords {
+		keywordJSON, _ := json.MarshalIndent(keyword, "", "  ")
+		fmt.Printf("%s\n", keywordJSON)
+	}
+
+}

--- a/v201702/cli/partial_failure.go
+++ b/v201702/cli/partial_failure.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config.Auth.PartialFailure = true
+
+	service := gads.NewAdGroupService(&config.Auth)
+
+	adGroupList := []gads.AdGroupLabel{
+		gads.AdGroupLabel{
+			AdGroupId: 1234567890,
+			LabelId:   1234567,
+		},
+		gads.AdGroupLabel{
+			AdGroupId: 1234567891,
+			LabelId:   1234567,
+		},
+		gads.AdGroupLabel{
+			AdGroupId: 1234567892,
+			LabelId:   1234567,
+		},
+	}
+
+	adGroupLabels, err := service.MutateLabel(
+		gads.AdGroupLabelOperations{
+			"ADD": adGroupList,
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(adGroupLabels)
+
+}

--- a/v201702/cli/report.go
+++ b/v201702/cli/report.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// The query you want to run
+var awql string = "Select AdGroupId,Id,CreativeQualityScore,PostClickQualityScore,SearchPredictedCtr,QualityScore FROM KEYWORDS_PERFORMANCE_REPORT DURING YESTERDAY"
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Report Service
+	rs := gads.NewReportDownloadService(&config.Auth)
+
+	res, err := rs.AWQL(awql, "CSV")
+
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	log.Println(res)
+}

--- a/v201702/cli/targeting_idea.go
+++ b/v201702/cli/targeting_idea.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201702"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tis := gads.NewTargetingIdeaService(&config.Auth)
+
+	ads, _, err := tis.Get(
+		gads.TargetingIdeaSelector{
+			IdeaType:    "KEYWORD",
+			RequestType: "IDEAS",
+			RequestedAttributeTypes: []string{
+				"CATEGORY_PRODUCTS_AND_SERVICES",
+				"COMPETITION",
+				"EXTRACTED_FROM_WEBPAGE",
+				"IDEA_TYPE",
+				"KEYWORD_TEXT",
+				"SEARCH_VOLUME",
+				"AVERAGE_CPC",
+				"TARGETED_MONTHLY_SEARCHES",
+			},
+			SearchParameters: []gads.SearchParameter{
+				gads.CategoryProductsAndServicesSearchParameter{
+					CategoryID: 51,
+				},
+				gads.CompetitionSearchParameter{
+					Levels: []string{"MEDIUM", "HIGH"},
+				},
+				gads.IdeaTextFilterSearchParameter{
+					Included: []string{},
+					Excluded: []string{"red herring e3a2b4b7", "red herring 418f2d72"},
+				},
+				gads.IncludeAdultContentSearchParameter{},
+				gads.LanguageSearchParameter{
+					Languages: []gads.LanguageCriterion{
+						gads.LanguageCriterion{Id: 1000},
+					},
+				},
+				gads.LocationSearchParameter{
+					Locations: []gads.Location{
+						gads.Location{Id: 2840},
+						gads.Location{Id: 2124},
+					},
+				},
+				gads.NetworkSearchParameter{
+					NetworkSetting: gads.NetworkSetting{
+						TargetGoogleSearch: true,
+					},
+				},
+				gads.RelatedToQuerySearchParameter{
+					Queries: []string{"blue herring", "test"},
+				},
+				gads.RelatedToUrlSearchParameter{
+					Urls: []string{"https://google.com"},
+				},
+				gads.SearchVolumeSearchParameter{
+					Minimum: 3900000,
+					Maximum: 5445394,
+				},
+				// gads.SeedAdGroupIdSearchParameter{
+				// 	AdGroupID: 123456,
+				// },
+			},
+			Paging: gads.Paging{
+				Offset: 0,
+				Limit:  3,
+			},
+		},
+	)
+
+	fmt.Println(ads)
+	adsJSON, err := json.MarshalIndent(ads, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", adsJSON)
+
+}

--- a/v201702/constant_data.go
+++ b/v201702/constant_data.go
@@ -1,0 +1,181 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type ConstantDataService struct {
+	Auth
+}
+
+func NewConstantDataService(auth *Auth) *ConstantDataService {
+	return &ConstantDataService{Auth: *auth}
+}
+
+func (s *ConstantDataService) GetAgeRangeCriterion() (ageRanges []AgeRangeCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getAgeRangeCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getAgeRangeCriterion"`
+		}{},
+	)
+	if err != nil {
+		return ageRanges, err
+	}
+	getResp := struct {
+		AgeRangeCriterions []AgeRangeCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return ageRanges, err
+	}
+	return getResp.AgeRangeCriterions, err
+}
+
+func (s *ConstantDataService) GetCarrierCriterion() (carriers []CarrierCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getCarrierCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getCarrierCriterion"`
+		}{},
+	)
+	if err != nil {
+		return carriers, err
+	}
+	getResp := struct {
+		CarrierCriterions []CarrierCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return carriers, err
+	}
+	return getResp.CarrierCriterions, err
+}
+
+func (s *ConstantDataService) GetGenderCriterion() (genders []GenderCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getGenderCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getGenderCriterion"`
+		}{},
+	)
+	if err != nil {
+		return genders, err
+	}
+	getResp := struct {
+		GenderCriterions []GenderCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return genders, err
+	}
+	return getResp.GenderCriterions, err
+}
+
+func (s *ConstantDataService) GetLanguageCriterion() (languages []LanguageCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getLanguageCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getLanguageCriterion"`
+		}{},
+	)
+	if err != nil {
+		return languages, err
+	}
+	getResp := struct {
+		LanguageCriterions []LanguageCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return languages, err
+	}
+	return getResp.LanguageCriterions, err
+}
+
+func (s *ConstantDataService) GetMobileDeviceCriterion() (mobileDevices []MobileDeviceCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getMobileDeviceCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getMobileDeviceCriterion"`
+		}{},
+	)
+	if err != nil {
+		return mobileDevices, err
+	}
+	getResp := struct {
+		MobileDeviceCriterions []MobileDeviceCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return mobileDevices, err
+	}
+	return getResp.MobileDeviceCriterions, err
+}
+
+func (s *ConstantDataService) GetOperatingSystemVersionCriterion() (operatingSystemVersions []OperatingSystemVersionCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getOperatingSystemVersionCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getOperatingSystemVersionCriterion"`
+		}{},
+	)
+	if err != nil {
+		return operatingSystemVersions, err
+	}
+	getResp := struct {
+		OperatingSystemVersionCriterions []OperatingSystemVersionCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return operatingSystemVersions, err
+	}
+	return getResp.OperatingSystemVersionCriterions, err
+}
+
+func (s *ConstantDataService) GetUserInterestCriterion() (userInterests []UserInterestCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getUserInterestCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getUserInterestCriterion"`
+		}{},
+	)
+	if err != nil {
+		return userInterests, err
+	}
+	getResp := struct {
+		UserInterestCriterions []UserInterestCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return userInterests, err
+	}
+	return getResp.UserInterestCriterions, err
+}
+
+func (s *ConstantDataService) GetVerticalCriterion() (verticals []VerticalCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getVerticalCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201702 getVerticalCriterion"`
+		}{},
+	)
+	if err != nil {
+		return verticals, err
+	}
+	getResp := struct {
+		VerticalCriterions []VerticalCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return verticals, err
+	}
+	return getResp.VerticalCriterions, err
+}

--- a/v201702/constant_data.go
+++ b/v201702/constant_data.go
@@ -138,6 +138,34 @@ func (s *ConstantDataService) GetOperatingSystemVersionCriterion() (operatingSys
 	return getResp.OperatingSystemVersionCriterions, err
 }
 
+func (s *ConstantDataService) GetProductBiddingCategoryCriterion(selector Selector) (categoryData []ProductBiddingCategoryData, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getProductBiddingCategoryData",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: "https://adwords.google.com/api/adwords/cm/v201702",
+				Local: "getProductBiddingCategoryData",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return categoryData, err
+	}
+	getResp := struct {
+		ProductBiddingCategoryDatas []ProductBiddingCategoryData `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return categoryData, err
+	}
+	return getResp.ProductBiddingCategoryDatas, err
+}
+
 func (s *ConstantDataService) GetUserInterestCriterion() (userInterests []UserInterestCriterion, err error) {
 	respBody, err := s.Auth.request(
 		constantDataServiceUrl,

--- a/v201702/constant_data_test.go
+++ b/v201702/constant_data_test.go
@@ -1,0 +1,89 @@
+package v201702
+
+import (
+	//"fmt"
+	"testing"
+)
+
+func testConstantDataService(t *testing.T) (service *ConstantDataService) {
+	return &ConstantDataService{Auth: testAuthSetup(t)}
+}
+
+func TestConstantData(t *testing.T) {
+	/*
+			cds := testConstantDataService(t)
+
+			ageRangeCriterions, err := cds.GetAgeRangeCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("Age Range\n")
+		  for _, ageRange := range ageRangeCriterions {
+		    //fmt.Printf("%d. %s\n",ageRange.Id,ageRange.AgeRangeType)
+		    fmt.Printf("%d. %#v\n",ageRange.Id,ageRange)
+		  }
+
+			carrierCriterions, err := cds.GetCarrierCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nCarrier\n")
+		  for _, carrier := range carrierCriterions {
+		    fmt.Printf("%d. %s,%s\n",carrier.Id, carrier.Name,carrier.CountryCode)
+		  }
+
+			genderCriterions, err := cds.GetGenderCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nGender\n")
+		  for _, gender := range genderCriterions {
+		    fmt.Printf("%d. %s\n",gender.Id, gender.GenderType)
+		  }
+
+			languageCriterions, err := cds.GetLanguageCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nLanguage\n")
+		  for _, language := range languageCriterions {
+		    fmt.Printf("%d. %s,%s\n", language.Id, language.Code, language.Name)
+		  }
+
+			mobileDeviceCriterions, err := cds.GetMobileDeviceCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nMobile Device\n")
+		  for _, mobile := range mobileDeviceCriterions {
+		    fmt.Printf("%d. %s,%s\n", mobile.Id, mobile.DeviceName, mobile.DeviceType)
+		  }
+
+			operatingSystemVersionCriterions, err := cds.GetOperatingSystemVersionCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nOperating System Version\n")
+		  for _, osv := range operatingSystemVersionCriterions {
+		    fmt.Printf("%d. %s,%s\n", osv.Id, osv.Name, osv.OperatorType)
+		  }
+
+			userInterestCriterions, err := cds.GetUserInterestCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nUser Interest\n")
+		  for _, userInterest := range userInterestCriterions {
+		    fmt.Printf("%d. %s\n", userInterest.Id, userInterest.Name)
+		  }
+
+			verticalCriterions, err := cds.GetVerticalCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nVertical\n")
+		  for _, vertical := range verticalCriterions {
+		    fmt.Printf("%d. %#v\n",vertical.Id, vertical.Path)
+		  }
+	*/
+}

--- a/v201702/conversion_tracker.go
+++ b/v201702/conversion_tracker.go
@@ -1,0 +1,14 @@
+package v201702
+
+type ConversionTrackingSettings struct {
+	EffectiveConversionTrackingId      int64 `xml:effectiveConversionTrackingId`
+	UsesCrossAccountConversionTracking bool  `xml:usesCrossAccountConversionTracking`
+}
+
+type ConversionTrackerService struct {
+	Auth
+}
+
+func NewConversionTrackerService(auth *Auth) *ConversionTrackerService {
+	return &ConversionTrackerService{Auth: *auth}
+}

--- a/v201702/criterion.go
+++ b/v201702/criterion.go
@@ -164,6 +164,22 @@ type ProductCriterion struct {
 	Text       string             `xml:"text,omitempty"`
 }
 
+// Represents a google_product_category level
+type ProductBiddingCategory ProductDimension
+
+type ProductBiddingCategoryData struct {
+	DimensionValue       ProductBiddingCategory `xml:"dimensionValue"`
+	ParentDimensionValue ProductBiddingCategory `xml:"parentDimensionValue"`
+	Country              string                 `xml:"country"`
+	Status               string                 `xml:"status"`
+	DisplayValue         []StringMapEntry       `xml:"displayValue"`
+}
+
+type StringMapEntry struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
 type GeoPoint struct {
 	Latitude  int64 `xml:"latitudeInMicroDegrees"`
 	Longitude int64 `xml:"longitudeInMicroDegrees"`

--- a/v201702/criterion.go
+++ b/v201702/criterion.go
@@ -1,0 +1,402 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// DayOfWeek: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+// StartHour: 0~23 inclusive
+// StartMinute: ZERO, FIFTEEN, THIRTY, FORTY_FIVE
+// EndHour: 0~24 inclusive
+// EndMinute: ZERO, FIFTEEN, THIRTY, FORTY_FIVE
+type AdScheduleCriterion struct {
+	Id          int64  `xml:"id,omitempty"`
+	DayOfWeek   string `xml:"dayOfWeek"`
+	StartHour   string `xml:"startHour"`
+	StartMinute string `xml:"startMinute"`
+	EndHour     string `xml:"endHour"`
+	EndMinute   string `xml:"endMinute"`
+}
+
+// AgeRangeType: AGE_RANGE_18_24, AGE_RANGE_25_34, AGE_RANGE_35_44, AGE_RANGE_45_54, AGE_RANGE_55_64, AGE_RANGE_65_UP, AGE_RANGE_UNDETERMINED, UNKNOWN
+type AgeRangeCriterion struct {
+	Id           int64  `xml:"id,omitempty"`
+	AgeRangeType string `xml:"ageRangeType"`
+}
+
+type CarrierCriterion struct {
+	Id          int64  `xml:"id,omitempty"`
+	Name        string `xml:"name,emitempty"`
+	CountryCode string `xml:"countryCode,emitempty"`
+}
+
+type ContentLabelCriterion struct {
+	Id               int64  `xml:"id,omitempty"`
+	ContentLabelType string `xml:"contentLabelType"` // ContentLabelType: "ADULTISH", "AFE", "BELOW_THE_FOLD", "CONFLICT", "DP", "EMBEDDED_VIDEO", "GAMES", "JACKASS", "PROFANITY", "UGC_FORUMS", "UGC_IMAGES", "UGC_SOCIAL", "UGC_VIDEOS", "SIRENS", "TRAGEDY", "VIDEO", "UNKNOWN"
+}
+
+type GenderCriterion struct {
+	Id         int64  `xml:"id,omitempty"`
+	GenderType string `xml:"genderType"` // GenderType:  "GENDER_MALE", "GENDER_FEMALE", "GENDER_UNDETERMINED"
+}
+
+type KeywordCriterion struct {
+	Id        int64  `xml:"https://adwords.google.com/api/adwords/cm/v201702 id,omitempty"`
+	Text      string `xml:"https://adwords.google.com/api/adwords/cm/v201702 text,omitempty"`      // Text: up to 80 characters and ten words
+	MatchType string `xml:"https://adwords.google.com/api/adwords/cm/v201702 matchType,omitempty"` // MatchType:  "EXACT", "PHRASE", "BROAD"
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.Keyword
+// Represents a keyword.
+type Keyword struct {
+	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201702 id,omitempty"`
+	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201702 type,omitempty"`
+	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201702 Criterion.Type,omitempty"`
+
+	Text      string           `xml:"https://adwords.google.com/api/adwords/cm/v201702 text,omitempty"`
+	MatchType KeywordMatchType `xml:"https://adwords.google.com/api/adwords/cm/v201702 matchType,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.KeywordMatchType
+// Match type of a keyword. i.e. the way we match a keyword string with search queries.
+// EXACT, PHRASE, BROAD
+type KeywordMatchType string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.Criterion.Type
+// The types of criteria
+type CriterionType string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.LocationTargetingStatus
+// Enum that represents the different Targeting Status values for a Location criterion.
+// ACTIVE, OBSOLETE, PHASING_OUT
+type LocationTargetingStatus string
+
+type LanguageCriterion struct {
+	Id   int64  `xml:"https://adwords.google.com/api/adwords/cm/v201702 id,omitempty"`
+	Code string `xml:"https://adwords.google.com/api/adwords/cm/v201702 code,omitempty"`
+	Name string `xml:"https://adwords.google.com/api/adwords/cm/v201702 name,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.Location
+// Represents Location criterion.  A criterion of this type can only be created using an ID.
+// LocationName:
+// DisplayType:
+// TargetingStatus: ACTIVE, OBSOLETE, PHASING_OUT
+// ParentLocations:
+type Location struct {
+	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201702 id,omitempty"`
+	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201702 type,omitempty"`
+	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201702 Criterion.Type,omitempty"`
+
+	LocationName    string                  `xml:"https://adwords.google.com/api/adwords/cm/v201702 locationName,omitempty"`
+	DisplayType     string                  `xml:"https://adwords.google.com/api/adwords/cm/v201702 displayType,omitempty"`
+	TargetingStatus LocationTargetingStatus `xml:"https://adwords.google.com/api/adwords/cm/v201702 targetingStatus,omitempty"`
+	ParentLocations []Location              `xml:"https://adwords.google.com/api/adwords/cm/v201702 parentLocations,omitempty"`
+}
+
+// MobileAppCategoryId:
+//   https://developers.google.com/adwords/api/docs/appendix/mobileappcategories
+// DisplayName:
+type MobileAppCategoryCriterion struct {
+	Id                  int64  `xml:"id,omitempty"`
+	MobileAppCategoryId int64  `xml:"mobileAppCategoryId"`
+	DisplayName         string `xml:"displayName,omitempty"`
+}
+
+// AppId: "{platform}-{platform_native_id}"
+// DisplayName:
+type MobileApplicationCriterion struct {
+	Id          int64  `xml:"id,omitempty"`
+	AppId       string `xml:"appId"`
+	DisplayName string `xml:"displayName,omitempty"`
+}
+
+// DeviceName:
+// ManufacturerName:
+// DeviceType:  DEVICE_TYPE_MOBILE, DEVICE_TYPE_TABLET
+// OperatingSystemName:
+type MobileDeviceCriterion struct {
+	Id                  int64  `xml:"id,omitempty"`
+	DeviceName          string `xml:"deviceName,omitempty"`
+	ManufacturerName    string `xml:"manufacturerName,omitempty"`
+	DeviceType          string `xml:"deviceType,omitempty"`
+	OperatingSystemName string `xml:"operatingSystemName,omitempty"`
+}
+
+// Name:
+// OsMajorVersion:
+// OsMinorVersion:
+// OperatorType: GREATER_THAN_EQUAL_TO, EQUAL_TO, UNKNOWN
+type OperatingSystemVersionCriterion struct {
+	Id             int64  `xml:"id,omitempty"`
+	Name           string `xml:"name,omitempty"`
+	OsMajorVersion int64  `xml:"osMajorVersion,omitempty"`
+	OsMinorVersion int64  `xml:"osMinorVersion,omitempty"`
+	OperatorType   string `xml:"operatorType,omitempty"`
+}
+
+// Url:
+type PlacementCriterion struct {
+	Id  int64  `xml:"id,omitempty"`
+	Url string `xml:"url"`
+}
+
+// PlatformId:
+//  Desktop	30000
+//  HighEndMobile	30001
+//  Tablet	30002
+type PlatformCriterion struct {
+	Id           int64  `xml:"id,omitempty"`
+	PlatformName string `xml:"platformName,omitempty"`
+}
+
+// Argument:
+// Operand: id, product_type, brand, adwords_grouping, condition, adwords_labels
+type ProductCondition struct {
+	Argument string `xml:"argument"`
+	Operand  string `xml:"operand"`
+}
+
+type ProductCriterion struct {
+	Id         int64              `xml:"id,omitempty"`
+	Conditions []ProductCondition `xml:"conditions"`
+	Text       string             `xml:"text,omitempty"`
+}
+
+type GeoPoint struct {
+	Latitude  int64 `xml:"latitudeInMicroDegrees"`
+	Longitude int64 `xml:"longitudeInMicroDegrees"`
+}
+
+type Address struct {
+	StreetAddress  string `xml:"streetAddress"`
+	StreetAddress2 string `xml:"streetAddress2"`
+	CityName       string `xml:"cityName"`
+	ProvinceCode   string `xml:"provinceCode"`
+	ProvinceName   string `xml:"provinceName"`
+	PostalCode     string `xml:"postalCode"`
+	CountryCode    string `xml:"countryCode"`
+}
+
+type ProductDimension struct {
+	Type          string `xml:"ProductDimension.Type"`
+	DimensionType string `xml:"type"`
+	Value         string `xml:"value"`
+}
+
+type ProductPartition struct {
+	Id                int64            `xml:"id,omitempty"`
+	CriteriaType      string           `xml:"type"`
+	PartitionType     string           `xml:"partitionType,omitempty"`
+	ParentCriterionId int64            `xml:"parentCriterionId,omitempty"`
+	Dimension         ProductDimension `xml:"caseValue"`
+	Cpc               *Cpc             // This value is inherited from BiddableAdgroupCriterion
+}
+
+type ProductScope struct {
+	Id           int64              `xml:"id,omitempty"`
+	CriteriaType string             `xml:"type"`
+	Dimensions   []ProductDimension `xml:"dimensions"`
+}
+
+// RadiusDistanceUnits: KILOMETERS, MILES
+// RadiusUnits:
+type ProximityCriterion struct {
+	Id                  int64    `xml:"id,omitempty"`
+	GeoPoint            GeoPoint `xml:"geoPoint"`
+	RadiusDistanceUnits string   `xml:"radiusDistanceUnits"`
+	RadiusInUnits       float64  `xml:"radiusInUnits"`
+	Address             Address  `xml:"address"`
+}
+
+type UserInterestCriterion struct {
+	Id   int64  `xml:"userInterestId,omitempty"`
+	Name string `xml:"userInterestName"`
+}
+
+type UserListCriterion struct {
+	Id                       int64  `xml:"id,omitempty"`
+	UserListId               int64  `xml:"userListId"`
+	UserListName             string `xml:"userListName"`
+	UserListMembershipStatus string `xml:"userListMembershipStatus"`
+}
+
+type VerticalCriterion struct {
+	Id       int64    `xml:"verticalId,omitempty"`
+	ParentId int64    `xml:"verticalParentId"`
+	Path     []string `xml:"path"`
+}
+
+type WebpageCondition struct {
+	Operand  string `xml:"operand"`
+	Argument string `xml:"argument"`
+}
+
+type WebpageParameter struct {
+	CriterionName string             `xml:"criterionName"`
+	Conditions    []WebpageCondition `xml:"conditions"`
+}
+
+type WebpageCriterion struct {
+	Id               int64            `xml:"id,omitempty"`
+	Parameter        WebpageParameter `xml:"parameter"`
+	CriteriaCoverage float64          `xml:"criteriaCoverage"`
+	CriteriaSamples  []string         `xml:"criteriaSamples"`
+}
+
+type Criterion interface{}
+
+func criterionUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (Criterion, error) {
+	criterionType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return nil, err
+	}
+	switch criterionType {
+	case "AdSchedule":
+		c := AdScheduleCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "AgeRange":
+		c := AgeRangeCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Carrier":
+		c := CarrierCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ContentLabel":
+		c := ContentLabelCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Gender":
+		c := GenderCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Keyword":
+		c := KeywordCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Language":
+		c := LanguageCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Location":
+		c := Location{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "MobileAppCategory":
+		c := MobileAppCategoryCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "MobileApplication":
+		c := MobileApplicationCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "MobileDevice":
+		c := MobileDeviceCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "OperatingSystemVersion":
+		c := OperatingSystemVersionCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Placement":
+		c := PlacementCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Platform":
+		c := PlatformCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Product":
+		c := ProductCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ProductPartition":
+		c := ProductPartition{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ProductScope":
+		c := ProductScope{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Proximity":
+		c := ProximityCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "CriterionUserInterest":
+		c := UserInterestCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "CriterionUserList":
+		c := UserListCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Vertical":
+		c := VerticalCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Webpage":
+		c := WebpageCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	default:
+		return nil, fmt.Errorf("unknown criterion type %#v", criterionType)
+	}
+}
+
+func criterionMarshalXML(c Criterion, e *xml.Encoder) error {
+	criterionType := ""
+	switch t := c.(type) {
+	case AdScheduleCriterion:
+		criterionType = "AdSchedule"
+	case AgeRangeCriterion:
+		criterionType = "AgeRange"
+	case CarrierCriterion:
+		criterionType = "Carrier"
+	case ContentLabelCriterion:
+		criterionType = "ContentLabel"
+	case GenderCriterion:
+		criterionType = "Gender"
+	case KeywordCriterion:
+		criterionType = "Keyword"
+	case LanguageCriterion:
+		criterionType = "Language"
+	case Location:
+		criterionType = "Location"
+	case MobileAppCategoryCriterion:
+		criterionType = "MobileAppCategory"
+	case MobileApplicationCriterion:
+		criterionType = "MobileApplication"
+	case MobileDeviceCriterion:
+		criterionType = "MobileDevice"
+	case OperatingSystemVersionCriterion:
+		criterionType = "OperatingSystemVersion"
+	case PlacementCriterion:
+		criterionType = "Placement"
+	case PlatformCriterion:
+		criterionType = "Platform"
+	case ProductCriterion:
+		criterionType = "Product"
+	case ProximityCriterion:
+		criterionType = "Proximity"
+	case UserInterestCriterion:
+		criterionType = "CriterionUserInterest"
+	case UserListCriterion:
+		criterionType = "CriterionUserList"
+	case VerticalCriterion:
+		criterionType = "Vertical"
+	case WebpageCriterion:
+		criterionType = "Webpage"
+	default:
+		return fmt.Errorf("unknown criterion type %#v\n", t)
+	}
+	e.EncodeElement(&c, xml.StartElement{
+		xml.Name{baseUrl, "criterion"},
+		[]xml.Attr{
+			xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, criterionType},
+		},
+	})
+	return nil
+}

--- a/v201702/customer.go
+++ b/v201702/customer.go
@@ -1,0 +1,57 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type CustomerService struct {
+	Auth
+}
+
+type Customer struct {
+	CustomerId                 int64                      `xml:"customerId"`
+	CurrencyCode               string                     `xml:"currencyCode"`
+	DateTimeZone               string                     `xml:"dateTimeZone"`
+	DescriptiveName            string                     `xml:"descriptiveName"`
+	CompanyName                string                     `xml:"companyName"`
+	CanManageClients           bool                       `xml:"canManageClients"`
+	TestAccount                bool                       `xml:"testAccount"`
+	AutoTaggingEnabled         bool                       `xml:"autoTaggingEnabled"`
+	TrackingUrlTemplate        string                     `xml:"trackingUrlTemplate,omitempty"`
+	ConversionTrackingSettings ConversionTrackingSettings `xml:"conversionTrackingSettings"`
+	RemarketingSettings        RemarketingSettings        `xml:"remarketingSettings"`
+}
+
+type RemarketingSettings struct {
+	Snippet string `xml:"snippet"`
+}
+
+func NewCustomerService(auth *Auth) *CustomerService {
+	return &CustomerService{Auth: *auth}
+}
+
+func (s *CustomerService) GetCustomers() (customers []Customer, err error) {
+	respBody, err := s.Auth.request(
+		customerServiceUrl,
+		"getCustomers",
+		struct {
+			XMLName xml.Name
+		}{
+			XMLName: xml.Name{
+				Space: baseMcmUrl,
+				Local: "getCustomers",
+			},
+		},
+	)
+	if err != nil {
+		return customers, err
+	}
+	getResp := struct {
+		Customers []Customer `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return customers, err
+	}
+	return getResp.Customers, nil
+}

--- a/v201702/customer.go
+++ b/v201702/customer.go
@@ -13,7 +13,6 @@ type Customer struct {
 	CurrencyCode               string                     `xml:"currencyCode"`
 	DateTimeZone               string                     `xml:"dateTimeZone"`
 	DescriptiveName            string                     `xml:"descriptiveName"`
-	CompanyName                string                     `xml:"companyName"`
 	CanManageClients           bool                       `xml:"canManageClients"`
 	TestAccount                bool                       `xml:"testAccount"`
 	AutoTaggingEnabled         bool                       `xml:"autoTaggingEnabled"`

--- a/v201702/customer_feed.go
+++ b/v201702/customer_feed.go
@@ -1,0 +1,9 @@
+package v201702
+
+type CustomerFeedService struct {
+	Auth
+}
+
+func NewCustomerFeedService(auth *Auth) *CustomerFeedService {
+	return &CustomerFeedService{Auth: *auth}
+}

--- a/v201702/customer_sync.go
+++ b/v201702/customer_sync.go
@@ -1,0 +1,9 @@
+package v201702
+
+type CustomerSyncService struct {
+	Auth
+}
+
+func NewCustomerSyncService(auth *Auth) *CustomerSyncService {
+	return &CustomerSyncService{Auth: *auth}
+}

--- a/v201702/data.go
+++ b/v201702/data.go
@@ -1,0 +1,250 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type DataService struct {
+	Auth
+}
+
+func NewDataService(auth *Auth) *DataService {
+	return &DataService{Auth: *auth}
+}
+
+type LandscapePoint struct {
+	Bid                 *int64 `xml:"bid>microAmount,omitempty"`
+	Clicks              *int64 `xml:"clicks,omitempty"`
+	Cost                *int64 `xml:"cost>microAmount,omitempty"`
+	Impressions         *int64 `xml:"impressions,omitempty"`
+	PromotedImpressions *int64 `xml:"promotedImpressions,omitempty"`
+}
+
+type BidLandscape struct {
+	CampaignId      *int64           `xml:"campaignId,omitempty"`
+	AdGroupId       *int64           `xml:"adGroupId,omitempty"`
+	StartDate       *string          `xml:"startDate,omitempty"`
+	EndDate         *string          `xml:"endDate,omitempty"`
+	LandscapePoints []LandscapePoint `xml:"landscapePoints"`
+}
+
+type AdGroupBidLandscape struct {
+	BidLandscape
+	Type             string  `xml:"type"`
+	LandscapeCurrent bool    `xml:"landscapeCurrent"`
+	Errors           []error `xml:"-"`
+}
+
+type CriterionBidLandscape struct {
+	BidLandscape
+	CriterionId *int64 `xml:"criterionId,omitempty"`
+}
+
+// GetAdGroupBidLandscape returns an array of AdGroupBidLandscape objects
+// the selector.
+//
+// Example
+//
+//   adGroupBidLandscape, totalCount, err := dataService.GetAdGroupBidLandscape(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//         "Bid",
+//         "CampaignId",
+//         "LocalClicks",
+//         "LocalCost",
+//		   "LocalImpressions",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"AdGroupId", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "Bid", "CampaignId", "EndDate", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions", "StartDate"
+//
+// filterable fields are
+//   "AdGroupId", "Bid", "CampaignId", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/DataService#getadgroupbidlandscape
+//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201702-DataService
+//
+func (s *DataService) GetAdGroupBidLandscape(selector Selector) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
+	// The default namespace, "", will break in 1.5 with the addition of
+	// custom namespace support.  Hence, we have to ensure that the baseUrl is
+	// set again as the proper namespace for the service/serviceSelector element
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"getAdGroupBidLandscape",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "getAdGroupBidLandscape",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+	getResp := struct {
+		Size                 int64                 `xml:"rval>totalNumEntries"`
+		AdGroupBidLandscapes []AdGroupBidLandscape `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+	return getResp.AdGroupBidLandscapes, getResp.Size, err
+}
+
+// GetCriterionBidLandscape returns an array of CriterionBidLandscape objects
+// the selector.
+//
+// Example
+//
+//   criterionBidLandscape, totalCount, err := dataService.GetCriterionBidLandscape(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//		   "CriterionId",
+//         "Bid",
+//         "CampaignId",
+//         "LocalClicks",
+//         "LocalCost",
+//		   "LocalImpressions",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"CriterionId", "EQUALS", []string{criterionId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "Bid", "CampaignId", "CriterionId", "EndDate", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions", "StartDate"
+//
+// filterable fields are
+//   "AdGroupId", "Bid", "CampaignId", "CriterionId", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/DataService#getcriterionbidlandscape
+//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201702-DataService
+//
+func (s *DataService) GetCriterionBidLandscape(selector Selector) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
+	// The default namespace, "", will break in 1.5 with the addition of
+	// custom namespace support.  Hence, we have to ensure that the baseUrl is
+	// set again as the proper namespace for the service/serviceSelector element
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"getCriterionBidLandscape",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "getCriterionBidLandscape",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+	getResp := struct {
+		Size                   int64                   `xml:"rval>totalNumEntries"`
+		CriterionBidLandscapes []CriterionBidLandscape `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+	return getResp.CriterionBidLandscapes, getResp.Size, err
+}
+
+// QueryAdGroupBidLandscape returns a slice of AdGroupBidLandscapes based on passed in AWQL query
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/DataService#queryadgroupbidlandscape
+//
+func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"queryAdGroupBidLandscape",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "queryAdGroupBidLandscape",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+
+	getResp := struct {
+		Size                 int64                 `xml:"rval>totalNumEntries"`
+		AdGroupBidLandscapes []AdGroupBidLandscape `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+	return getResp.AdGroupBidLandscapes, getResp.Size, err
+}
+
+// QueryCriterionBidLandscape returns a slice of CriterionBidLandscapes based on passed in AWQL query
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201702/DataService#querycriterionbidlandscape
+//
+func (s *DataService) QueryCriterionBidLandscape(query string) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"queryCriterionBidLandscape",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "queryCriterionBidLandscape",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+
+	getResp := struct {
+		Size                   int64                   `xml:"rval>totalNumEntries"`
+		CriterionBidLandscapes []CriterionBidLandscape `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+	return getResp.CriterionBidLandscapes, getResp.Size, err
+}

--- a/v201702/doc.go
+++ b/v201702/doc.go
@@ -1,0 +1,30 @@
+// Package gads provides a wrapper for the Google Adwords SOAP API.
+// In order to access the API you will need to sign up for an MMC
+// account[1], get a developer token[2], setup authentication[3].  The is
+// a tool in the setup_oauth2 directory that will setup a configuration
+// file.
+//
+// The package is comprised of services used to manipulate various
+// adwords structures.  To access a service you need to create an
+// gads.Auth and parse it to the service initializer, then can call
+// the service methods on the service object.
+//
+//     authConf, err := NewCredentials(context.TODO())
+//     campaignService := gads.NewCampaignService(&authConf.Auth)
+//
+//     campaigns, totalCount, err := cs.Get(
+//       gads.Selector{
+//         Fields: []string{
+//           "Id",
+//           "Name",
+//           "Status",
+//         },
+//       },
+//     )
+//
+// 1. http://www.google.com/adwords/myclientcenter/
+//
+// 2. https://developers.google.com/adwords/api/docs/signingup
+//
+// 3. https://developers.google.com/adwords/api/docs/guides/authentication
+package v201702

--- a/v201702/draft.go
+++ b/v201702/draft.go
@@ -1,0 +1,9 @@
+package v201702
+
+type DraftService struct {
+	Auth
+}
+
+func NewDraftService(auth *Auth) *DraftService {
+	return &DraftService{Auth: *auth}
+}

--- a/v201702/errors.go
+++ b/v201702/errors.go
@@ -1,0 +1,145 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type OperationError struct {
+	Code      int64  `xml:"OperationError>Code"`
+	Details   string `xml:"OperationError>Details"`
+	ErrorCode string `xml:"OperationError>ErrorCode"`
+	Message   string `xml:"OperationError>Message"`
+}
+
+type EntityError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type BudgetError struct {
+	EntityError
+}
+
+type CriterionError struct {
+	EntityError
+}
+
+type TargetError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type AdGroupServiceError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type NotEmptyError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type AdError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type LabelError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type UrlError struct {
+	EntityError
+}
+
+// if you exceed the quota given by google
+type RateExceededError struct {
+	RateName          string `xml:"rateName"`  // For example OperationsByMinute
+	RateScope         string `xml:"rateScope"` // ACCOUNT or DEVELOPER
+	ErrorString       string `xml:"errorString"`
+	Reason            string `xml:"reason"`
+	RetryAfterSeconds uint   `xml:"retryAfterSeconds"` // Try again in...
+}
+
+type ApiExceptionFault struct {
+	Message string        `xml:"message"`
+	Type    string        `xml:"ApplicationException.Type"`
+	Errors  []interface{} `xml:"errors"`
+}
+
+func (aes *ApiExceptionFault) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		switch start := token.(type) {
+		case xml.StartElement:
+			switch start.Name.Local {
+			case "message":
+				if err := dec.DecodeElement(&aes.Message, &start); err != nil {
+					return err
+				}
+			case "ApplicationException.Type":
+				if err := dec.DecodeElement(&aes.Type, &start); err != nil {
+					return err
+				}
+			case "errors":
+				errorType, _ := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+				switch errorType {
+				case "CriterionError", "TargetError", "BudgetError",
+					"AdGroupServiceError", "NotEmptyError", "LabelError",
+					"UrlError", "AdError", "ns2:UserListError":
+					e := EntityError{}
+					dec.DecodeElement(&e, &start)
+					aes.Errors = append(aes.Errors, e)
+				case "RateExceededError":
+					e := RateExceededError{}
+					dec.DecodeElement(&e, &start)
+					aes.Errors = append(aes.Errors, e)
+				default:
+					return fmt.Errorf("Unknown error type -> %s", start)
+				}
+			case "reason":
+				break
+			default:
+				return fmt.Errorf("Unknown error field -> %s", start)
+			}
+		}
+	}
+	return err
+}
+
+type ErrorsType struct {
+	ApiExceptionFaults []ApiExceptionFault `xml:"ApiExceptionFault"`
+}
+
+func (f ErrorsType) Error() string {
+	errors := []string{}
+	for _, e := range f.ApiExceptionFaults {
+		errors = append(errors, fmt.Sprintf("%s", e.Message))
+	}
+	return strings.Join(errors, "\n")
+}
+
+type Fault struct {
+	XMLName     xml.Name   `xml:"Fault"`
+	FaultCode   string     `xml:"faultcode"`
+	FaultString string     `xml:"faultstring"`
+	Errors      ErrorsType `xml:"detail"`
+}
+
+func (f Fault) Error() string {
+	return f.FaultString + " - " + f.Errors.Error()
+}

--- a/v201702/extension_setting.go
+++ b/v201702/extension_setting.go
@@ -1,0 +1,122 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.ExtensionSetting
+// A setting specifying when and which extensions should serve at a given level (customer, campaign, or ad group).
+type ExtensionSetting struct {
+	PlatformRestrictions ExtensionSettingPlatform `xml:"platformRestrictions,omitempty"`
+
+	Extensions Extension `xml:"https://adwords.google.com/api/adwords/cm/v201702 extensions,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.ExtensionSetting.Platform
+// Different levels of platform restrictions
+// DESKTOP, MOBILE, NONE
+type ExtensionSettingPlatform string
+
+type Extension interface{}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.ExtensionFeedItem
+// Contains base extension feed item data for an extension in an extension feed managed by AdWords.
+type ExtensionFeedItem struct {
+	XMLName xml.Name `json:"-" xml:"extensions"`
+
+	FeedId                  int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201702 feedId,omitempty"`
+	FeedItemId              int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201702 feedItemId,omitempty"`
+	Status                  *FeedItemStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201702 status,omitempty"`
+	FeedType                *FeedType                  `xml:"https://adwords.google.com/api/adwords/cm/v201702 feedType,omitempty"`
+	StartTime               string                     `xml:"https://adwords.google.com/api/adwords/cm/v201702 startTime,omitempty"` //  special value "00000101 000000" may be used to clear an existing start time.
+	EndTime                 string                     `xml:"https://adwords.google.com/api/adwords/cm/v201702 endTime,omitempty"`   //  special value "00000101 000000" may be used to clear an existing end time.
+	DevicePreference        *FeedItemDevicePreference  `xml:"https://adwords.google.com/api/adwords/cm/v201702 devicePreference,omitempty"`
+	Scheduling              *FeedItemScheduling        `xml:"https://adwords.google.com/api/adwords/cm/v201702 scheduling,omitempty"`
+	CampaignTargeting       *FeedItemCampaignTargeting `xml:"https://adwords.google.com/api/adwords/cm/v201702 campaignTargeting,omitempty"`
+	AdGroupTargeting        *FeedItemAdGroupTargeting  `xml:"https://adwords.google.com/api/adwords/cm/v201702 adGroupTargeting,omitempty"`
+	KeywordTargeting        *Keyword                   `xml:"https://adwords.google.com/api/adwords/cm/v201702 keywordTargeting,omitempty"`
+	GeoTargeting            *Location                  `xml:"https://adwords.google.com/api/adwords/cm/v201702 geoTargeting,omitempty"`
+	GeoTargetingRestriction *FeedItemGeoRestriction    `xml:"https://adwords.google.com/api/adwords/cm/v201702 geoTargetingRestriction,omitempty"`
+	PolicyData              *[]FeedItemPolicyData      `xml:"https://adwords.google.com/api/adwords/cm/v201702 policyData,omitempty"`
+
+	ExtensionFeedItemType string `xml:"https://adwords.google.com/api/adwords/cm/v201702 ExtensionFeedItem.Type,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.CallFeedItem
+// Represents a Call extension.
+type CallFeedItem struct {
+	ExtensionFeedItem
+
+	CallPhoneNumber               string             `xml:"https://adwords.google.com/api/adwords/cm/v201702 callPhoneNumber,omitempty"`
+	CallCountryCode               string             `xml:"https://adwords.google.com/api/adwords/cm/v201702 callCountryCode,omitempty"`
+	CallTracking                  bool               `xml:"https://adwords.google.com/api/adwords/cm/v201702 callTracking,omitempty"`
+	CallConversionType            CallConversionType `xml:"https://adwords.google.com/api/adwords/cm/v201702 callConversionType,omitempty"`
+	DisableCallConversionTracking bool               `xml:"https://adwords.google.com/api/adwords/cm/v201702 disableCallConversionTracking,omitempty"`
+}
+
+func extensionsUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (ext interface{}, err error) {
+	extensionsType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return
+	}
+	switch extensionsType {
+	case "CallFeedItem":
+		c := CallFeedItem{}
+		err = dec.DecodeElement(&c, &start)
+		ext = c
+	default:
+		err = fmt.Errorf("unknown Extensions type %#v", extensionsType)
+	}
+	return
+}
+
+func (s ExtensionSetting) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	e.EncodeToken(start)
+	if s.PlatformRestrictions != "NONE" {
+		e.EncodeElement(&s.PlatformRestrictions, xml.StartElement{Name: xml.Name{
+			"https://adwords.google.com/api/adwords/cm/v201702",
+			"platformRestrictions"}})
+	}
+	switch extType := s.Extensions.(type) {
+	case []CallFeedItem:
+		e.EncodeElement(s.Extensions.([]CallFeedItem), xml.StartElement{
+			xml.Name{baseUrl, "extensions"},
+			[]xml.Attr{
+				xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "CallFeedItem"},
+			},
+		})
+	default:
+		return fmt.Errorf("unknown extension type %#v\n", extType)
+
+	}
+
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (s *ExtensionSetting) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	s.Extensions = []interface{}{}
+
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			switch start.Name.Local {
+			case "platformRestrictions":
+				if err := dec.DecodeElement(&s.PlatformRestrictions, &start); err != nil {
+					return err
+				}
+			case "extensions":
+				extension, err := extensionsUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				s.Extensions = append(s.Extensions.([]interface{}), extension)
+			}
+		}
+	}
+	return nil
+}

--- a/v201702/feed.go
+++ b/v201702/feed.go
@@ -1,0 +1,87 @@
+package v201702
+
+import "encoding/xml"
+
+type FeedService struct {
+	Auth
+}
+
+func NewFeedService(auth *Auth) *FeedService {
+	return &FeedService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService
+func (s *FeedService) Query(query string) (page []Feed, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		feedServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	getResp := struct {
+		Size  int64  `xml:"rval>totalNumEntries"`
+		Feeds []Feed `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return
+	}
+	return getResp.Feeds, getResp.Size, err
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.Feed.Type
+// Feed hard type. Values coincide with placeholder type id.
+// Enum: NONE, SITELINK, CALL, APP, REVIEW, AD_CUSTOMIZER, CALLOUT, STRUCTURED_SNIPPET, PRICE
+type FeedType string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService.Feed.Status
+// Status of the Feed.
+// ENABLED, REMOVED, UNKNOWN
+type FeedStatus string
+
+// Used to Specify who manages the FeedAttributes for the Feed.
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService.Feed.Origin
+// USER, ADWORDS, UNKNOWN
+type FeedOrigin string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService.FeedAttribute.Type
+// Possible data types.
+type FeedAttributeType string
+
+// Configuration data allowing feed items to be populated for a system feed.
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService.SystemFeedGenerationData
+type SystemFeedGenerationData struct {
+	SystemFeedGenerationDataType string `xml:"https://adwords.google.com/api/adwords/cm/v201702 SystemFeedGenerationData.Type,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService.FeedAttribute
+// FeedAttributes define the types of data expected to be present in a Feed.
+// A single FeedAttribute specifies the expected type of the FeedItemAttributes with the same FeedAttributeId.
+// Optionally, a FeedAttribute can be marked as being part of a FeedItem's unique key.
+type FeedAttribute struct {
+	Id          int64             `xml:"https://adwords.google.com/api/adwords/cm/v201702 id,omitempty"`
+	Name        string            `xml:"https://adwords.google.com/api/adwords/cm/v201702 name,omitempty"`
+	Type        FeedAttributeType `xml:"https://adwords.google.com/api/adwords/cm/v201702 type,omitempty"`
+	IsPartOfKey bool              `xml:"https://adwords.google.com/api/adwords/cm/v201702 isPartOfKey,omitempty"`
+}
+
+// A Feed identifies a source of data and its schema.
+// The data for the Feed can either be user-entered via the FeedItemService or system-generated, in which case the data is provided automatically.
+// https://developers.google.com/adwords/api/docs/reference/v201702/FeedService.Feed
+type Feed struct {
+	Id                       int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201702 id,omitempty"`
+	Name                     string                     `xml:"https://adwords.google.com/api/adwords/cm/v201702 name,omitempty"`
+	Attributes               []FeedAttribute            `xml:"https://adwords.google.com/api/adwords/cm/v201702 attributes,omitempty"`
+	Status                   FeedStatus                 `xml:"https://adwords.google.com/api/adwords/cm/v201702 status,omitempty"`
+	Origin                   FeedOrigin                 `xml:"https://adwords.google.com/api/adwords/cm/v201702 origin,omitempty"`
+	SystemFeedGenerationData []SystemFeedGenerationData `xml:"https://adwords.google.com/api/adwords/cm/v201702 systemFeedGenerationData,omitempty"`
+}

--- a/v201702/feed_item.go
+++ b/v201702/feed_item.go
@@ -1,0 +1,104 @@
+package v201702
+
+type FeedItemService struct {
+	Auth
+}
+
+func NewFeedItemService(auth *Auth) *FeedItemService {
+	return &FeedItemService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItem.Status
+// ENABLED, REMOVED, UNKNOWN
+type FeedItemStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemDevicePreference
+// Represents a FeedItem device preference
+type FeedItemDevicePreference struct {
+	DevicePreference int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 devicePreference,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemScheduling
+// Represents a collection of FeedItem schedules specifying all time intervals for which the feed item may serve.
+// Any time range not covered by the specified FeedItemSchedules will prevent the feed item from serving during those times.
+type FeedItemScheduling struct {
+	feedItemSchedules int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 feedItemSchedules,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemSchedule
+// Represents a FeedItem schedule, which specifies a time interval on a given day when the feed item may serve.
+// The FeedItemSchedule times are in the account's time zone.
+type FeedItemSchedule struct {
+	DayOfWeek   DayOfWeek    `xml:"https://adwords.google.com/api/adwords/cm/v201702 dayOfWeek,omitempty"`
+	StartHour   int          `xml:"https://adwords.google.com/api/adwords/cm/v201702 startHour,omitempty"`
+	StartMinute MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201702 startMinute,omitempty"`
+	EndHour     int          `xml:"https://adwords.google.com/api/adwords/cm/v201702 endHour,omitempty"`
+	EndMinute   MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201702 endMinute,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemCampaignTargeting
+// Specifies the campaign the request context must match in order for the feed item to be considered eligible for serving (aka the targeted campaign).
+// E.g., if the below campaign targeting is set to campaignId = X, then the feed item can only serve under campaign X.
+type FeedItemCampaignTargeting struct {
+	TargetingCampaignId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 TargetingCampaignId,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemAdGroupTargeting
+// Specifies the adgroup the request context must match in order for the feed item to be considered eligible for serving (aka the targeted adgroup).
+// E.g., if the below adgroup targeting is set to adgroup = X, then the feed item can only serve under adgroup X.
+type FeedItemAdGroupTargeting struct {
+	TargetingAdGroupId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 TargetingAdGroupId,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemGeoRestriction
+// Represents a FeedItem geo restriction.
+type FeedItemGeoRestriction struct {
+	GeoRestriction GeoRestriction `xml:"https://adwords.google.com/api/adwords/cm/v201702 geoRestriction,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemPolicyData
+// Contains offline-validation and approval results for a given FeedItem and FeedMapping.
+// Each validation data indicates any issues found on the feed item when used in the context of the feed mapping.
+type FeedItemPolicyData struct {
+	PolicyData
+	PlaceholderType           int                               `xml:"https://adwords.google.com/api/adwords/cm/v201702 placeholderType,omitempty"`
+	FeedMappingId             int64                             `xml:"https://adwords.google.com/api/adwords/cm/v201702 feedMappingId,omitempty"`
+	ValidationStatus          FeedItemValidationStatus          `xml:"https://adwords.google.com/api/adwords/cm/v201702 validationStatus,omitempty"`
+	ApprovalStatus            FeedItemApprovalStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201702 approvalStatus,omitempty"`
+	ValidationErrors          []FeedItemAttributeError          `xml:"https://adwords.google.com/api/adwords/cm/v201702 validationErrors,omitempty"`
+	QualityApprovalStatus     FeedItemQualityApprovalStatus     `xml:"https://adwords.google.com/api/adwords/cm/v201702 qualityApprovalStatus,omitempty"`
+	QualityDisapprovalReasons FeedItemQualityDisapprovalReasons `xml:"https://adwords.google.com/api/adwords/cm/v201702 qualityDisapprovalReasons,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemValidationStatus
+// Validation status of a FeedItem
+// UNCHECKED, ERROR, VALID
+type FeedItemValidationStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemApprovalStatus
+// Feed item approval status
+// UNCHECKED, APPROVED, DISAPPROVED
+type FeedItemApprovalStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemAttributeError
+// Contains validation error details for a set of feed attributes
+type FeedItemAttributeError struct {
+	FeedAttributeIds    []int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 feedAttributeIds,omitempty"`
+	ValidationErrorCode int     `xml:"https://adwords.google.com/api/adwords/cm/v201702 validationErrorCode,omitempty"`
+	ErrorInformation    string  `xml:"https://adwords.google.com/api/adwords/cm/v201702 errorInformation,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemQualityApprovalStatus
+// Feed item quality evaluation approval status
+// UNCHECKED, APPROVED, DISAPPROVED
+type FeedItemQualityApprovalStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.FeedItemQualityDisapprovalReasons
+// Feed item quality evaluation disapproval reasons.
+type FeedItemQualityDisapprovalReasons string
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.CallConversionType
+// Conversion type for a call extension.
+type CallConversionType struct {
+	ConversionTypeId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201702 conversionTypeId,omitempty"`
+}

--- a/v201702/feed_mapping.go
+++ b/v201702/feed_mapping.go
@@ -1,0 +1,9 @@
+package v201702
+
+type FeedMappingService struct {
+	Auth
+}
+
+func NewFeedMappingService(auth *Auth) *FeedMappingService {
+	return &FeedMappingService{Auth: *auth}
+}

--- a/v201702/label.go
+++ b/v201702/label.go
@@ -1,0 +1,187 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type LabelService struct {
+	Auth
+}
+
+func NewLabelService(auth *Auth) *LabelService {
+	return &LabelService{Auth: *auth}
+}
+
+// Label represents a label.
+type Label struct {
+	Type   string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Id     int64  `xml:"id,omitempty"`
+	Name   string `xml:"name,omitempty"`
+	Status string `xml:"status,omitempty"`
+}
+
+// NewTextLabel returns an new Label struct for creating a new TextLabel.
+func NewTextLabel(name string) Label {
+	return Label{
+		Type: "TextLabel",
+		Name: name,
+	}
+}
+
+// LabelOperations is a map of operations to perform on Label's
+type LabelOperations map[string][]Label
+
+// Get returns an array of Label's and the total number of Label's matching
+// the selector.
+//
+// Example
+//
+//   labels, totalCount, err := labelService.Get(
+//     Selector{
+//       Fields: []string{"LabelId","LabelName","LabelStatus"},
+//       Predicates: []Predicate{
+//         {"LabelStatus", "EQUALS", []string{"ENABLED"}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "LabelId", "LabelName", "LabelStatus"
+//
+// filterable fields are
+//   "LabelId", "LabelName", "LabelStatus"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/LabelService#get
+//
+func (s LabelService) Get(selector Selector) (labels []Label, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		labelServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return labels, totalCount, err
+	}
+	getResp := struct {
+		Size   int64   `xml:"rval>totalNumEntries"`
+		Labels []Label `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return labels, totalCount, err
+	}
+	return getResp.Labels, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove labels, returning the
+// modified labels.
+//
+// Example
+//
+//  labels, err := labelService.Mutate(
+//    LabelOperations{
+//      "ADD": {
+//        NewTextLabel("Label1"),
+//        NewTextLabel("Label2"),
+//      },
+//      "SET": {
+//        modifiedLabel,
+//      },
+//      "REMOVE": {
+//        Label{Type:"TextLabel",Id:10},
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/LabelService#mutate
+//
+func (s *LabelService) Mutate(labelOperations LabelOperations) (labels []Label, err error) {
+	type labelOperation struct {
+		Action string `xml:"operator"`
+		Label  Label  `xml:"operand"`
+	}
+	operations := []labelOperation{}
+	for action, labels := range labelOperations {
+		for _, label := range labels {
+			operations = append(operations,
+				labelOperation{
+					Action: action,
+					Label:  label,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []labelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(labelServiceUrl, "mutate", mutation)
+	if err != nil {
+		return labels, err
+	}
+	mutateResp := struct {
+		Labels []Label `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return labels, err
+	}
+	return mutateResp.Labels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201506/LabelService#query
+//
+func (s *LabelService) Query(query string) (labels []Label, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		labelServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return labels, totalCount, err
+	}
+
+	getResp := struct {
+		Size   int64   `xml:"rval>totalNumEntries"`
+		Labels []Label `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return labels, totalCount, err
+	}
+	return getResp.Labels, getResp.Size, err
+
+}

--- a/v201702/label_test.go
+++ b/v201702/label_test.go
@@ -1,0 +1,83 @@
+package v201702
+
+import (
+	"testing"
+)
+
+func testLabelService(t *testing.T) (service *LabelService) {
+	return &LabelService{Auth: testAuthSetup(t)}
+}
+
+func testLabel(t *testing.T) (Label, func()) {
+	s := testLabelService(t)
+	labels, err := s.Mutate(
+		LabelOperations{
+			"ADD": {
+				NewTextLabel("Label_" + rand_str(10)),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupLabel := func() {
+		_, err = s.Mutate(LabelOperations{"REMOVE": labels})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	return labels[0], cleanupLabel
+}
+
+func TestLabel(t *testing.T) {
+	ls := testLabelService(t)
+	labels, err := ls.Mutate(
+		LabelOperations{
+			"ADD": {
+				NewTextLabel("Label" + rand_str(10)),
+				NewTextLabel("Label" + rand_str(10)),
+				NewTextLabel("Label" + rand_str(10)),
+				NewTextLabel("Label" + rand_str(10)),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundLabels, _, err := ls.Get(
+		Selector{
+			Fields: []string{
+				"LabelId",
+				"LabelName",
+				"LabelStatus",
+			},
+			Predicates: []Predicate{
+				{"LabelStatus", "EQUALS", []string{"ENABLED"}},
+			},
+			Ordering: []OrderBy{
+				{"LabelId", "ASCENDING"},
+			},
+			Paging: &Paging{
+				Offset: 0,
+				Limit:  500,
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("found %d labels\n", len(foundLabels))
+	for _, c := range labels {
+		func(label Label) {
+			for _, foundLabel := range foundLabels {
+				if foundLabel.Id == label.Id {
+					return
+				}
+			}
+			t.Errorf("label %d not found in \n%#v\n", label.Id, foundLabels)
+		}(c)
+	}
+}

--- a/v201702/location_criterion.go
+++ b/v201702/location_criterion.go
@@ -1,0 +1,52 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type LocationCriterionService struct {
+	Auth
+}
+
+func NewLocationCriterionService(auth *Auth) *LocationCriterionService {
+	return &LocationCriterionService{Auth: *auth}
+}
+
+type LocationCriterion struct {
+	Location      Location `xml:"location"`
+	CanonicalName string   `xml:"canonicalName,omitempty"`
+	Reach         string   `xml:"reach,omitempty"`
+	Locale        string   `xml:"locale,omitempty"`
+	SearchTerm    string   `xml:"searchTerm"`
+}
+
+type LocationCriterions []LocationCriterion
+
+func (s *LocationCriterionService) Get(selector Selector) (locationCriterions LocationCriterions, err error) {
+	selector.XMLName = xml.Name{baseUrl, "selector"}
+	respBody, err := s.Auth.request(
+		locationCriterionServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return locationCriterions, err
+	}
+	getResp := struct {
+		LocationCriterions LocationCriterions `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return locationCriterions, err
+	}
+	return getResp.LocationCriterions, err
+}

--- a/v201702/location_criterion_test.go
+++ b/v201702/location_criterion_test.go
@@ -1,0 +1,39 @@
+package v201702
+
+import (
+	"fmt"
+	"testing"
+	//  "encoding/xml"
+)
+
+func testLocationCriterionService(t *testing.T) (service *LocationCriterionService) {
+	return &LocationCriterionService{Auth: testAuthSetup(t)}
+}
+
+func TestLocationCriterion(t *testing.T) {
+	lcs := testLocationCriterionService(t)
+	locationCriterions, err := lcs.Get(
+		Selector{
+			Fields: []string{
+				"Id",
+				"LocationName",
+				"CanonicalName",
+				"DisplayType",
+				"ParentLocations",
+				"Reach",
+				"TargetingStatus",
+			},
+			Predicates: []Predicate{
+				{"LocationName", "IN", []string{"Cameroon", "India", "Iraq", "Nigeria", "Pakistan", "Philippines"}},
+				{"Locale", "EQUALS", []string{"en"}},
+			},
+		},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	for _, locationCriterion := range locationCriterions {
+		location := locationCriterion.Location
+		fmt.Printf("%d. %s, %s\n", location.Id, location.LocationName, location.DisplayType)
+	}
+}

--- a/v201702/managed_customer.go
+++ b/v201702/managed_customer.go
@@ -1,0 +1,117 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type ManagedCustomer struct {
+	Name                  string         `xml:"name"`
+	CustomerId            int64          `xml:"customerId,omitempty"`
+	CanManageClients      bool           `xml:"canManageClients,omitempty"`
+	CurrencyCode          string         `xml:"currencyCode"`
+	DateTimeZone          string         `xml:"dateTimeZone"`
+	TestAccount           bool           `xml:"testAccount,omitempty"`
+	AccountLabels         []AccountLabel `xml:"accountLabels,omitempty"`
+	ExcludeHiddenAccounts bool           `xml:"excludeHiddenAccounts,omitempty"`
+}
+
+type ManagedCustomerLink struct {
+	ManagerCustomerId      int64  `xml:"managerCustomerId"`
+	ClientCustomerId       int64  `xml:"clientCustomerId"`
+	LinkStatus             string `xml:"linkStatus"`
+	PendingDescriptiveName string `xml:"pendingDescriptiveName"`
+	IsHidden               bool   `xml:isHidden"`
+}
+
+type ManagedCustomerOperations map[string][]ManagedCustomer
+
+type ManagedCustomerPage struct {
+	Size                 int64                 `xml:"rval>totalNumEntries"`
+	ManagedCustomers     []ManagedCustomer     `xml:"rval>entries"`
+	ManagedCustomerLinks []ManagedCustomerLink `xml:"rval>links"`
+}
+
+type AccountLabel struct {
+	Id   int64  `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type ManagedCustomerService struct {
+	Auth
+}
+
+func NewManagedCustomerService(auth *Auth) *ManagedCustomerService {
+	return &ManagedCustomerService{Auth: *auth}
+}
+
+func (s *ManagedCustomerService) Get(selector Selector) (managedCustomerPage ManagedCustomerPage, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseMcmUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		managedCustomerServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseMcmUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return managedCustomerPage, totalCount, err
+	}
+	getResp := ManagedCustomerPage{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return managedCustomerPage, totalCount, err
+	}
+	return getResp, totalCount, nil
+}
+
+func (s *ManagedCustomerService) Mutate(managedCustomerOperations ManagedCustomerOperations) (managedCustomers []ManagedCustomer, err error) {
+	type managedCustomerOperation struct {
+		Action          string          `xml:"https://adwords.google.com/api/adwords/cm/v201702 operator"`
+		ManagedCustomer ManagedCustomer `xml:"operand"`
+	}
+
+	operations := []managedCustomerOperation{}
+	for action, managedCustomers := range managedCustomerOperations {
+		for _, managedCustomer := range managedCustomers {
+			operations = append(operations,
+				managedCustomerOperation{
+					Action:          action,
+					ManagedCustomer: managedCustomer,
+				},
+			)
+		}
+	}
+
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []managedCustomerOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseMcmUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+
+	respBody, err := s.Auth.request(managedCustomerServiceUrl, "mutate", mutation)
+	if err != nil {
+		return managedCustomers, err
+	}
+
+	mutateResp := struct {
+		ManagedCustomers []ManagedCustomer `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return managedCustomers, err
+	}
+
+	return mutateResp.ManagedCustomers, err
+}

--- a/v201702/media.go
+++ b/v201702/media.go
@@ -1,0 +1,133 @@
+package v201702
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+)
+
+type MediaService struct {
+	Auth
+}
+
+func NewMediaService(auth *Auth) *MediaService {
+	return &MediaService{Auth: *auth}
+}
+
+type Dimensions struct {
+	Name   string `xml:"key"` // "FULL", "SHRUNKEN", "PREVIEW", "VIDEO_THUMBNAIL"
+	Width  int64  `xml:"value>width"`
+	Height int64  `xml:"value>height"`
+}
+
+type ImageUrl struct {
+}
+
+// Media represents an audio, image or video file.
+type Media struct {
+	Type         string       `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Id           int64        `xml:"mediaId,omitempty"`
+	MediaType    string       `xml:"type"` // "AUDIO", "DYNAMIC_IMAGE", "ICON", "IMAGE", "STANDARD_ICON", "VIDEO"
+	ReferenceId  int64        `xml:"referenceId,omitempty"`
+	Dimensions   []Dimensions `xml:"dimensions"`
+	Urls         []ImageUrl   `xml:"urls"`
+	MimeType     string       `xml:"mimeType,omitempty"` // "IMAGE_JPEG", "IMAGE_GIF", "IMAGE_PNG", "FLASH", "TEXT_HTML", "PDF", "MSWORD", "MSEXCEL", "RTF", "AUDIO_WAV", "AUDIO_MP3"
+	SourceUrl    string       `xml:"sourceUrl,omitempty"`
+	Name         string       `xml:"name"`
+	FileSize     int64        `xml:"fileSize,omitempty"`   // File size in bytes
+	CreationTime string       `xml:"createTime,omitempty"` // format is YYYY-MM-DD HH:MM:SS+TZ
+
+	// Audio / Video
+	DurationMillis   int64  `xml:"durationMillis,omitempty"`
+	StreamingUrl     string `xml:"streamingUrl,omitempty"`
+	ReadyToPlayOnWeb bool   `xml:"readyToPlayOnTheWeb,omitempty"`
+
+	// Image
+	Data string `xml:"data,omitempty"` // base64Binary encoded raw image data
+
+	// Video
+	IndustryStandardCommercialIdentifier string `xml:"industryStandardCommercialIdentifier,omitempty"`
+	AdvertisingId                        string `xml:"advertisingId,omitempty"`
+	YouTubeVideoIdString                 string `xml:"youTubeVideoIdString,omitempty"`
+}
+
+func NewAudio(name, mediaType, mimeType string) (image Media) {
+	return Media{
+		Name: name,
+		Type: "Audio",
+	}
+}
+
+func NewImage(name, mediaType, mimeType string, data []byte) (image Media) {
+	imageData := base64.StdEncoding.EncodeToString(data)
+	return Media{
+		Name:      name,
+		Type:      "Image",
+		MediaType: mediaType,
+		Data:      imageData,
+	}
+}
+
+func NewVideo(mediaType string) (image Media) {
+	return Media{
+		Type: "Video",
+	}
+}
+
+func (s *MediaService) Get(selector Selector) (medias []Media, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		mediaServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return medias, totalCount, err
+	}
+	getResp := struct {
+		Size   int64   `xml:"rval>totalNumEntries"`
+		Medias []Media `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return medias, totalCount, err
+	}
+	return getResp.Medias, getResp.Size, err
+}
+
+func (s *MediaService) Query(query string) (medias []Media, totalCount int64, err error) {
+	return medias, totalCount, ERROR_NOT_YET_IMPLEMENTED
+}
+
+func (s *MediaService) Upload(medias []Media) (uploadedMedias []Media, err error) {
+	upload := struct {
+		XMLName xml.Name
+		Medias  []Media `xml:"media"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "upload",
+		},
+		Medias: medias,
+	}
+	respBody, err := s.Auth.request(mediaServiceUrl, "upload", upload)
+	if err != nil {
+		return uploadedMedias, err
+	}
+	uploadResp := struct {
+		Medias []Media `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &uploadResp)
+	if err != nil {
+		return uploadedMedias, err
+	}
+	return uploadResp.Medias, err
+}

--- a/v201702/media_test.go
+++ b/v201702/media_test.go
@@ -1,0 +1,78 @@
+package v201702
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func testMediaService(t *testing.T) (service *MediaService) {
+	return &MediaService{Auth: testAuthSetup(t)}
+}
+
+func TestMedia(t *testing.T) {
+
+	// load image into []byte
+	imageUrl := "http://www.google.com/intl/en/adwords/select/images/samples/inline.jpg"
+	resp, err := http.Get(imageUrl)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	ms := testMediaService(t)
+	images, err := ms.Upload(
+		[]Media{
+			NewImage("image1", "IMAGE", "IMAGE_JPEG", body),
+			NewImage("image2", "IMAGE", "IMAGE_JPEG", body),
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v", images)
+
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	for {
+		medias, totalCount, err := ms.Get(
+			Selector{
+				Fields: []string{
+					"MediaId",
+					"Height",
+					"Width",
+					"MimeType",
+					"Urls",
+				},
+				Predicates: []Predicate{
+					{"Type", "IN", []string{"IMAGE", "VIDEO"}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding medias")
+		}
+		for _, m := range medias {
+			for _, d := range m.Dimensions {
+				if d.Name == "FULL" {
+					fmt.Printf("Entry ID %d with dimensions %dx%d and MIME type is '%s'\n", m.Id, d.Height, d.Width, m.MimeType)
+				}
+			}
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			fmt.Printf("\tFound %d entries.", totalCount)
+			break
+		}
+	}
+
+}

--- a/v201702/misc_test.go
+++ b/v201702/misc_test.go
@@ -1,0 +1,29 @@
+package v201702
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"io/ioutil"
+	"net/http"
+)
+
+func ExampleMediaService_Upload() {
+	// load image into []byte
+	imageUrl := "http://www.google.com/intl/en/adwords/select/images/samples/inline.jpg"
+	resp, err := http.Get(imageUrl)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	// load credentials from
+	authConf, _ := NewCredentials(context.TODO())
+	ms := NewMediaService(&authConf.Auth)
+
+	images, err := ms.Upload([]Media{NewImage("image1", "IMAGE", "IMAGE_JPEG", body)})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v", images)
+}

--- a/v201702/negative_ad_group_criterion.go
+++ b/v201702/negative_ad_group_criterion.go
@@ -1,0 +1,60 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type NegativeAdGroupCriterion struct {
+	AdGroupId    int64     `xml:"adGroupId"`
+	CriterionUse string    `xml:"criterionUse"`
+	Criterion    Criterion `xml:"criterion"`
+}
+
+func (nagc NegativeAdGroupCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"NegativeAdGroupCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&nagc.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+	criterionMarshalXML(nagc.Criterion, e)
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (nagc *NegativeAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "adGroupId":
+				if err := dec.DecodeElement(&nagc.AdGroupId, &start); err != nil {
+					return err
+				}
+			case "criterionUse":
+				if err := dec.DecodeElement(&nagc.CriterionUse, &start); err != nil {
+					return err
+				}
+			case "criterion":
+				criterion, err := criterionUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				nagc.Criterion = criterion
+			case "AdGroupCriterion.Type":
+				break
+			default:
+				return fmt.Errorf("unknown NegativeAdGroupCriterion field %s", tag)
+			}
+		}
+	}
+	return nil
+}

--- a/v201702/oauth2.go
+++ b/v201702/oauth2.go
@@ -1,0 +1,109 @@
+package v201702
+
+import (
+	"encoding/json"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"time"
+)
+
+type AuthConfig struct {
+	file         string             `json:"-"`
+	OAuth2Config *oauth2.Config     `json:"oauth2.Config"`
+	OAuth2Token  *oauth2.Token      `json:"oauth2.Token"`
+	tokenSource  oauth2.TokenSource `json:"-"`
+	Auth         Auth               `json:"gads.Auth"`
+}
+
+type OAuthConfigArgs struct {
+	ClientID     string
+	ClientSecret string
+}
+
+type OAuthTokenArgs struct {
+	AccessToken  string
+	RefreshToken string
+}
+
+type Credentials struct {
+	Config OAuthConfigArgs
+	Token  OAuthTokenArgs
+	Auth   Auth
+}
+
+func NewCredentialsFromFile(pathToFile string) (ac AuthConfig, err error) {
+	ctx := context.TODO()
+	data, err := ioutil.ReadFile(pathToFile)
+	if err != nil {
+		return ac, err
+	}
+	if err := json.Unmarshal(data, &ac); err != nil {
+		return ac, err
+	}
+	ac.file = pathToFile
+	ac.tokenSource = ac.OAuth2Config.TokenSource(ctx, ac.OAuth2Token)
+	ac.Auth.Client = ac.OAuth2Config.Client(ctx, ac.OAuth2Token)
+	return ac, err
+}
+
+func NewCredentialsFromParams(creds Credentials) (config AuthConfig, err error) {
+	var gcfg AuthConfig
+
+	expiresAt, _ := time.Parse(time.RFC3339, "2015-07-28T14:51:53.543430418-04:00")
+
+	// Create a token
+	gcfg.OAuth2Token = &oauth2.Token{
+		AccessToken:  creds.Token.AccessToken,
+		TokenType:    "Bearer",
+		RefreshToken: creds.Token.RefreshToken,
+		Expiry:       expiresAt,
+	}
+	ctx := context.TODO()
+
+	gcfg.OAuth2Config = &oauth2.Config{
+		ClientID:     creds.Config.ClientID,
+		ClientSecret: creds.Config.ClientSecret,
+		Scopes: []string{
+			"https://adwords.google.com/api/adwords",
+		},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+			TokenURL: "https://accounts.google.com/o/oauth2/token",
+		},
+	}
+
+	gcfg.Auth = Auth{
+		CustomerId:     creds.Auth.CustomerId,
+		DeveloperToken: creds.Auth.DeveloperToken,
+		Client:         gcfg.OAuth2Config.Client(ctx, gcfg.OAuth2Token),
+	}
+
+	return gcfg, nil
+}
+
+// Save writes the contents of AuthConfig back to the JSON file it was
+// loaded from.
+func (c AuthConfig) Save() error {
+	configData, err := json.MarshalIndent(&c, "", "    ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(c.file, configData, 0600)
+}
+
+// Token implements oauth2.TokenSource interface and store updates to
+// config file.
+func (c AuthConfig) Token() (token *oauth2.Token, err error) {
+	// use cached token
+	if c.OAuth2Token.Valid() {
+		return c.OAuth2Token, err
+	}
+
+	// get new token from tokens source and store
+	c.OAuth2Token, err = c.tokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	return token, c.Save()
+}

--- a/v201702/offline_conversion_feed.go
+++ b/v201702/offline_conversion_feed.go
@@ -1,0 +1,9 @@
+package v201702
+
+type OfflineConversionService struct {
+	Auth
+}
+
+func NewOfflineConversionService(auth *Auth) *OfflineConversionService {
+	return &OfflineConversionService{Auth: *auth}
+}

--- a/v201702/page.go
+++ b/v201702/page.go
@@ -1,0 +1,8 @@
+package v201702
+
+// https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupExtensionSettingService.Page
+// Contains the results from a get call.
+type Page struct {
+	TotalNumEntries int    `xml:"https://adwords.google.com/api/adwords/cm/v201702 totalNumEntries,omitempty"`
+	PageType        string `xml:"https://adwords.google.com/api/adwords/cm/v201702 Page.Type,omitempty"`
+}

--- a/v201702/report_definition.go
+++ b/v201702/report_definition.go
@@ -1,0 +1,73 @@
+package v201702
+
+import (
+	"encoding/xml"
+)
+
+type ReportDefinition struct {
+	Selector       Selector `xml:"selector"`
+	ReportName     string   `xml:"reportName"`
+	ReportType     string   `xml:"reportType"`
+	DateRangeType  string   `xml:"dateRangeType"`
+	DownloadFormat string   `xml:"downloadFormat"`
+}
+
+type ReportDefinitionField struct {
+	FieldName           string          `xml:"fieldName"`
+	DisplayFieldName    string          `xml:"displayFieldName"`
+	XmlAttributeName    string          `xml:"xmlAttributeName"`
+	FieldType           string          `xml:"fieldType"`
+	FieldBehavior       string          `xml:"fieldBehavior"`
+	EnumValues          []string        `xml:"enumValues"`
+	CanSelect           bool            `xml:"canSelect"`
+	CanFilter           bool            `xml:"canFilter"`
+	IsEnumType          bool            `xml:"isEnumType"`
+	IsBeta              bool            `xml:"isBeta"`
+	IsZeroRowCompatible bool            `xml:"isZeroRowCompatible"`
+	EnumValuePairs      []EnumValuePair `xml:"enumValuePairs"`
+}
+
+type EnumValuePair struct {
+	EnumValue        string `xml:"enumValue"`
+	EnumDisplayValue string `xml:"enumDisplayvalue"`
+}
+
+type ReportDefinitionService struct {
+	Auth
+}
+
+type ReportDefinitionRequest struct {
+	ReportType string `xml:"reportType"`
+}
+
+func NewReportDefinitionService(auth *Auth) *ReportDefinitionService {
+	return &ReportDefinitionService{Auth: *auth}
+}
+
+func (s *ReportDefinitionService) GetReportFields(report string) (fields []ReportDefinitionField, err error) {
+	respBody, err := s.Auth.request(
+		reportDefinitionServiceUrl,
+		"get",
+		struct {
+			XMLName    xml.Name
+			ReportType string `xml:"reportType"`
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "getReportFields",
+			},
+			ReportType: report,
+		},
+	)
+	if err != nil {
+		return fields, err
+	}
+	getResp := struct {
+		Fields []ReportDefinitionField `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return fields, err
+	}
+	return getResp.Fields, err
+}

--- a/v201702/report_download.go
+++ b/v201702/report_download.go
@@ -1,0 +1,117 @@
+package v201702
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/xml"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type ReportDownloadService struct {
+	Auth
+}
+
+type reportDefinitionXml struct {
+	*ReportDefinition
+	XMLName xml.Name
+}
+
+func NewReportDownloadService(auth *Auth) *ReportDownloadService {
+	return &ReportDownloadService{Auth: *auth}
+}
+
+func (s *ReportDownloadService) Get(reportDefinition ReportDefinition) (res interface{}, err error) {
+	reportDefinition.Selector.XMLName = xml.Name{baseUrl, "selector"}
+	repDef := reportDefinitionXml{
+		ReportDefinition: &reportDefinition,
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "reportDefinition",
+		},
+	}
+	body, err := xml.MarshalIndent(repDef, "  ", "  ")
+	if err != nil {
+		return res, err
+	}
+	form := url.Values{}
+	form.Add("__rdxml", string(body))
+	resp, err := s.makeRequest(form)
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+	/*respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return res, err
+	}
+	return string(respBody), err*/
+	return parseReport(resp.Body)
+}
+
+func (s *ReportDownloadService) AWQL(awql string, fmt string) (res interface{}, err error) {
+	form := url.Values{}
+	form.Add("__rdquery", awql)
+	form.Add("__fmt", fmt)
+	resp, err := s.makeRequest(form)
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+	/*respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return res, err
+	}
+	return string(respBody), err*/
+
+	// if we didn't get a 200 bubble up the error
+	if resp.StatusCode != 200 {
+		response, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return res, err
+		}
+		return res, errors.New(string(response))
+	}
+
+	return parseReport(resp.Body)
+}
+
+// Make our http request using the given form (re-usable for either XML or AWQL)
+func (s *ReportDownloadService) makeRequest(form url.Values) (res *http.Response, err error) {
+	req, err := http.NewRequest("POST", reportDownloadServiceUrl.Url, bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return res, err
+	}
+	req.Header.Add("developerToken", s.Auth.DeveloperToken)
+	req.Header.Add("clientCustomerId", s.Auth.CustomerId)
+	req.Header.Add("skipReportHeader", "true")
+	req.Header.Add("skipReportSummary", "true")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	return s.Client.Do(req)
+}
+
+func parseReport(report io.Reader) (collection []map[string]string, err error) {
+	reader := csv.NewReader(report)
+	header, err := reader.Read()
+	if err != nil {
+		return collection, err
+	}
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return collection, err
+		}
+		row := make(map[string]string)
+		for i := 0; i < len(record); i++ {
+			column := header[i]
+			row[column] = record[i]
+		}
+		collection = append(collection, row)
+	}
+	return collection, err
+}

--- a/v201702/shared_criterion.go
+++ b/v201702/shared_criterion.go
@@ -1,0 +1,9 @@
+package v201702
+
+type SharedCriterionService struct {
+	Auth
+}
+
+func NewSharedCriterionService(auth *Auth) *SharedCriterionService {
+	return &SharedCriterionService{Auth: *auth}
+}

--- a/v201702/shared_set.go
+++ b/v201702/shared_set.go
@@ -1,0 +1,9 @@
+package v201702
+
+type SharedSetService struct {
+	Auth
+}
+
+func NewSharedSetService(auth *Auth) *SharedSetService {
+	return &SharedSetService{Auth: *auth}
+}

--- a/v201702/targeting_idea.go
+++ b/v201702/targeting_idea.go
@@ -1,0 +1,311 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// TargetingIdeaService Use this service to generate new keyword ideas based on the parameters specified in the selector. See the TargetingIdeaSelector documentation for more details.
+// You can also use this service to retrieve statistics for existing keyword ideas by setting the selector's requestType to RequestType.STATS and passing in the appropriate search parameters.
+type TargetingIdeaService struct {
+	Auth
+}
+
+// NewTargetingIdeaService returns a new TargetingIdeaService
+func NewTargetingIdeaService(auth *Auth) *TargetingIdeaService {
+	return &TargetingIdeaService{Auth: *auth}
+}
+
+// TargetingIdeaSelector A descriptor for finding TargetingIdeas that match the specified criteria.
+// https://developers.google.com/adwords/api/docs/reference/v201702/TargetingIdeaService.TargetingIdeaSelector
+type TargetingIdeaSelector struct {
+	SearchParameters        []SearchParameter `xml:"searchParameters"`
+	IdeaType                string            `xml:"ideaType"`
+	RequestType             string            `xml:"requestType"`
+	RequestedAttributeTypes []string          `xml:"requestedAttributeTypes"`
+	Paging                  Paging            `xml:"paging"`
+	LocaleCode              string            `xml:"localeCode,omitempty"`
+	CurrencyCode            string            `xml:"currencyCode,omitempty"`
+}
+
+type SearchParameter interface{}
+
+type CategoryProductsAndServicesSearchParameter struct {
+	CategoryID int `xml:"categoryId"`
+}
+
+type CompetitionSearchParameter struct {
+	Levels []string `xml:"levels"`
+}
+
+type IdeaTextFilterSearchParameter struct {
+	Included []string `xml:"included"`
+	Excluded []string `xml:"excluded"`
+}
+
+type IncludeAdultContentSearchParameter struct{}
+
+type LanguageSearchParameter struct {
+	Languages []LanguageCriterion `xml:"languages"`
+}
+
+type LocationSearchParameter struct {
+	Locations []Location `xml:"locations"`
+}
+
+type NetworkSearchParameter struct {
+	NetworkSetting NetworkSetting `xml:"networkSetting"`
+}
+
+type RelatedToQuerySearchParameter struct {
+	Queries []string `xml:"queries"`
+}
+
+type RelatedToUrlSearchParameter struct {
+	Urls           []string `xml:"urls"`
+	IncludeSubUrls bool     `xml:"includeSubUrls"`
+}
+
+type SearchVolumeSearchParameter struct {
+	Minimum int `xml:"operation>minimum"`
+	Maximum int `xml:"operation>maximum"`
+}
+
+type SeedAdGroupIdSearchParameter struct {
+	AdGroupID int64 `xml:"adGroupId"`
+}
+
+type TargetingIdeas struct {
+	TargetingIdea []TargetingIdea `xml:"data"`
+}
+
+type TargetingIdea struct {
+	Key   string    `xml:"key"`
+	Value Attribute `xml:"value"`
+}
+
+type BooleanAttribute struct {
+	Value bool `xml:"value"`
+}
+
+type DoubleAttribute struct {
+	Value float64 `xml:"value"`
+}
+
+type IdeaTypeAttribute struct {
+	Value string `xml:"value"`
+}
+
+type IntegerSetAttribute struct {
+	Value []int `xml:"value"`
+}
+
+type LongAttribute struct {
+	Value int64 `xml:"value"`
+}
+
+type MoneyAttribute struct {
+	Value int64 `xml:"value>microAmount"`
+}
+
+type MonthlySearchVolumeAttribute struct {
+	Value []MonthlySearchVolume `xml:"value"`
+}
+
+type StringAttribute struct {
+	Value string `xml:"value"`
+}
+
+type WebpageDescriptorAttribute struct {
+	Value WebpageDescriptor `xml:"value"`
+}
+
+type WebpageDescriptor struct {
+	Url   string `xml:"url"`
+	Title string `xml:"title"`
+}
+
+type MonthlySearchVolume struct {
+	Year  int   `xml:"year"`
+	Month int   `xml:"month"`
+	Count int64 `xml:"count"`
+}
+
+type Attribute interface{}
+
+func (ti *TargetingIdea) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "key":
+				var key string
+				err := dec.DecodeElement(&key, &start)
+				if err != nil {
+					return err
+				}
+				ti.Key = key
+			case "value":
+				value, err := attributeUnmarshalXML(dec, start)
+				// because there are multiple "value" elements we only want the ones that have an xsi attr
+				if err != nil {
+					break
+				}
+				ti.Value = value
+			}
+		}
+	}
+	return nil
+}
+
+func attributeUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (Attribute, error) {
+	attributeType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return nil, err
+	}
+	switch attributeType {
+	case "BooleanAttribute":
+		ba := BooleanAttribute{}
+		err := dec.DecodeElement(&ba, &start)
+		return ba.Value, err
+	case "DoubleAttribute":
+		da := DoubleAttribute{}
+		err := dec.DecodeElement(&da, &start)
+		return da.Value, err
+	case "IdeaTypeAttribute":
+		ita := IdeaTypeAttribute{}
+		err := dec.DecodeElement(&ita, &start)
+		return ita.Value, err
+	case "IntegerSetAttribute":
+		isa := IntegerSetAttribute{}
+		err := dec.DecodeElement(&isa, &start)
+		return isa.Value, err
+	case "LongAttribute":
+		la := LongAttribute{}
+		err := dec.DecodeElement(&la, &start)
+		return la.Value, err
+	case "MoneyAttribute":
+		ma := MoneyAttribute{}
+		err := dec.DecodeElement(&ma, &start)
+		return ma.Value, err
+	case "MonthlySearchVolumeAttribute":
+		msva := MonthlySearchVolumeAttribute{}
+		err := dec.DecodeElement(&msva, &start)
+		return msva.Value, err
+	case "StringAttribute":
+		sa := StringAttribute{}
+		err := dec.DecodeElement(&sa, &start)
+		return sa.Value, err
+	case "WebpageDescriptorAttribute":
+		wda := WebpageDescriptorAttribute{}
+		err := dec.DecodeElement(&wda, &start)
+		return wda.Value, err
+	default:
+		return nil, fmt.Errorf("unknown attribute type %#v", attributeType)
+	}
+}
+
+func (tis TargetingIdeaSelector) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+
+	e.EncodeToken(start)
+
+	for _, searchParam := range tis.SearchParameters {
+		err := searchParameterMarshalXML(searchParam, e)
+		if err != nil {
+			return err
+		}
+	}
+
+	e.EncodeElement(&tis.IdeaType, xml.StartElement{Name: xml.Name{"", "ideaType"}})
+	e.EncodeElement(&tis.RequestType, xml.StartElement{Name: xml.Name{"", "requestType"}})
+	e.EncodeElement(&tis.RequestedAttributeTypes, xml.StartElement{Name: xml.Name{"", "requestedAttributeTypes"}})
+	e.EncodeElement(&tis.Paging, xml.StartElement{Name: xml.Name{"", "paging"}})
+
+	if tis.LocaleCode != "" {
+		e.EncodeElement(&tis.LocaleCode, xml.StartElement{Name: xml.Name{"", "localCode"}})
+	}
+
+	if tis.CurrencyCode != "" {
+		e.EncodeElement(&tis.CurrencyCode, xml.StartElement{Name: xml.Name{"", "currencyCode"}})
+	}
+
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func searchParameterMarshalXML(sp SearchParameter, e *xml.Encoder) error {
+	searchType := ""
+
+	switch t := sp.(type) {
+	case CategoryProductsAndServicesSearchParameter:
+		searchType = "CategoryProductsAndServicesSearchParameter"
+	case CompetitionSearchParameter:
+		searchType = "CompetitionSearchParameter"
+	case IdeaTextFilterSearchParameter:
+		searchType = "IdeaTextFilterSearchParameter"
+	case IncludeAdultContentSearchParameter:
+		searchType = "IncludeAdultContentSearchParameter"
+	case LanguageSearchParameter:
+		searchType = "LanguageSearchParameter"
+	case LocationSearchParameter:
+		searchType = "LocationSearchParameter"
+	case NetworkSearchParameter:
+		searchType = "NetworkSearchParameter"
+	case RelatedToQuerySearchParameter:
+		searchType = "RelatedToQuerySearchParameter"
+	case RelatedToUrlSearchParameter:
+		searchType = "RelatedToUrlSearchParameter"
+	case SearchVolumeSearchParameter:
+		searchType = "SearchVolumeSearchParameter"
+	case SeedAdGroupIdSearchParameter:
+		searchType = "SeedAdGroupIdSearchParameter"
+	default:
+		return fmt.Errorf("unknown search parameter type %#v\n", t)
+	}
+
+	// encode the inner element
+	e.EncodeElement(&sp, xml.StartElement{
+		xml.Name{"", "searchParameters"},
+		[]xml.Attr{
+			xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, searchType},
+		},
+	})
+
+	return nil
+}
+
+// Get Returns a page of ideas that match the query described by the specified TargetingIdeaSelector.
+// https://developers.google.com/adwords/api/docs/reference/v201702/TargetingIdeaService
+func (s *TargetingIdeaService) Get(selector TargetingIdeaSelector) (targetingIdeas []TargetingIdeas, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		targetingIdeaServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     TargetingIdeaSelector `xml:"selector"`
+		}{
+			XMLName: xml.Name{
+				Space: baseTrafficUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return targetingIdeas, totalCount, err
+	}
+	getResp := struct {
+		Size           int64            `xml:"rval>totalNumEntries"`
+		TargetingIdeas []TargetingIdeas `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return targetingIdeas, totalCount, err
+	}
+	return getResp.TargetingIdeas, getResp.Size, err
+}

--- a/v201702/traffic_estimator.go
+++ b/v201702/traffic_estimator.go
@@ -1,0 +1,143 @@
+package v201702
+
+import "encoding/xml"
+
+type TrafficEstimatorService struct {
+	Auth
+}
+
+func NewTrafficEstimatorService(auth *Auth) *TrafficEstimatorService {
+	return &TrafficEstimatorService{Auth: *auth}
+}
+
+type KeywordEstimateRequest struct {
+	Keyword KeywordCriterion `xml:"keyword"`
+}
+
+type AdGroupEstimateRequest struct {
+	KeywordEstimateRequests []KeywordEstimateRequest `xml:"keywordEstimateRequests"`
+	MaxCpc                  int64                    `xml:"https://adwords.google.com/api/adwords/cm/v201702 maxCpc>microAmount"`
+}
+
+type CampaignEstimateRequest struct {
+	AdGroupEstimateRequests []AdGroupEstimateRequest `xml:"adGroupEstimateRequests"`
+}
+
+type TrafficEstimatorSelector struct {
+	CampaignEstimateRequests []CampaignEstimateRequest `xml:"campaignEstimateRequests"`
+}
+
+type StatsEstimate struct {
+	AverageCpc        int64   `xml:"averageCpc>microAmount"`
+	AveragePosition   float64 `xml:"averagePosition"`
+	ClickThroughRate  float64 `xml:"clickThroughRate"`
+	ClicksPerDay      float64 `xml:"clicksPerDay"`
+	ImpressionsPerDay float64 `xml:"impressionsPerDay"`
+	TotalCost         int64   `xml:"totalCost>microAmount"`
+}
+
+type KeywordEstimate struct {
+	Min StatsEstimate `xml:"min"`
+	Max StatsEstimate `xml:"max"`
+}
+
+type AdGroupEstimate struct {
+	KeywordEstimates []KeywordEstimate `xml:"keywordEstimates"`
+}
+
+type CampaignEstimate struct {
+	AdGroupEstimates []AdGroupEstimate `xml:"adGroupEstimates"`
+}
+
+// Get returns an array of CampaignEstimates, holding AdGroupEstimates which
+// hold KeywordEstimates, which hold the minimum and maximum values based on
+// the requested keywords.
+//
+// Example
+//
+//	keywordEstimateRequests := []KeywordEstimateRequest{
+//		KeywordEstimateRequest{
+//			KeywordCriterion{
+//				Text:      "mars cruise",
+//				MatchType: "BROAD",
+//			},
+//		},
+//		KeywordEstimateRequest{
+//			KeywordCriterion{
+//				Text:      "cheap cruise",
+//				MatchType: "EXACT",
+//			},
+//		},
+//		KeywordEstimateRequest{
+//			KeywordCriterion{
+//				Text:      "cruise",
+//				MatchType: "EXACT",
+//			},
+//		},
+//	}
+//
+//	adGroupEstimateRequests := []AdGroupEstimateRequest{
+//		AdGroupEstimateRequest{
+//			KeywordEstimateRequests: keywordEstimateRequests,
+//			MaxCpc:                  1000000,
+//		},
+//	}
+//
+//	campaignEstimateRequests := []CampaignEstimateRequest{
+//		CampaignEstimateRequest{
+//			AdGroupEstimateRequests: adGroupEstimateRequests,
+//		},
+//	}
+//
+//	estimates, err := trafficEstimatorService.Get(TrafficEstimatorSelector{
+//		CampaignEstimateRequests: campaignEstimateRequests,
+//	})
+//
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	for _, estimate := range estimates {
+//		for _, adGroupEstimate := range estimate.AdGroupEstimates {
+//			for _, keywordEstimate := range adGroupEstimate.KeywordEstimates {
+//				fmt.Printf("Avg cpc: %d", keywordEstimate.Min.AverageCpc)
+//			}
+//		}
+//	}
+//
+// Relevant documentation
+//
+// 		https://developers.google.com/adwords/api/docs/reference/v201702/TrafficEstimatorService#get
+//
+func (s *TrafficEstimatorService) Get(selector TrafficEstimatorSelector) (res []CampaignEstimate, err error) {
+
+	respBody, err := s.Auth.request(
+		trafficEstimatorServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     TrafficEstimatorSelector `xml:"selector"`
+		}{
+			XMLName: xml.Name{
+				Space: baseTrafficUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+
+	if err != nil {
+		return res, err
+	}
+
+	getResp := struct {
+		CampaignEstimates []CampaignEstimate `xml:"rval>campaignEstimates"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return res, err
+	}
+
+	return getResp.CampaignEstimates, err
+}

--- a/v201702/trial.go
+++ b/v201702/trial.go
@@ -1,0 +1,9 @@
+package v201702
+
+type TrialService struct {
+	Auth
+}
+
+func NewTrialService(auth *Auth) *TrialService {
+	return &TrialService{Auth: *auth}
+}

--- a/v201702/xml.go
+++ b/v201702/xml.go
@@ -1,0 +1,16 @@
+package v201702
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+func findAttr(as []xml.Attr, name xml.Name) (value string, err error) {
+	for _, a := range as {
+		an := a.Name
+		if an.Space == name.Space && an.Local == name.Local {
+			return a.Value, nil
+		}
+	}
+	return "", fmt.Errorf("attribute %#v not found", name)
+}

--- a/v201705/LICENSE
+++ b/v201705/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2015 Edward Middleton
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[Except as contained in this notice, the name of Edward Middleton
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+from Edward Middleton.]

--- a/v201705/ad_group.go
+++ b/v201705/ad_group.go
@@ -1,0 +1,287 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type AdGroupService struct {
+	Auth
+}
+
+func NewAdGroupService(auth *Auth) *AdGroupService {
+	return &AdGroupService{Auth: *auth}
+}
+
+type TargetSettingDetail struct {
+	CriterionTypeGroup string `xml:"criterionTypeGroup"`
+	TargetAll          bool   `xml:"targetAll"`
+}
+
+type AdSetting struct {
+	XMLName xml.Name `xml:"settings"`
+	Type    string   `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+
+	OptIn   *bool                 `xml:"optIn"`
+	Details []TargetSettingDetail `xml:"details"`
+}
+
+type AdGroup struct {
+	Id                           int64                          `xml:"id,omitempty"`
+	CampaignId                   int64                          `xml:"campaignId,omitempty"`
+	CampaignName                 string                         `xml:"campaignName,omitempty"`
+	Name                         string                         `xml:"name,omitempty"`
+	Status                       string                         `xml:"status,omitempty"`
+	Settings                     []AdSetting                    `xml:"settings,omitempty"`
+	BiddingStrategyConfiguration []BiddingStrategyConfiguration `xml:"biddingStrategyConfiguration"`
+	ContentBidCriterionTypeGroup *string                        `xml:"contentBidCriterionTypeGroup"`
+	UrlCustomParameters          *CustomParameters              `xml:"urlCustomParameters"`
+}
+
+type AdGroupOperations map[string][]AdGroup
+
+type AdGroupLabel struct {
+	AdGroupId int64 `xml:"adGroupId"`
+	LabelId   int64 `xml:"labelId"`
+}
+
+type AdGroupLabelOperations map[string][]AdGroupLabel
+
+// Get returns an array of ad group's and the total number of ad group's matching
+// the selector.
+//
+// Example
+//
+//   ads, totalCount, err := adGroupService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "Id",
+//         "CampaignId",
+//         "CampaignName",
+//         "Name",
+//         "Status",
+//         "Settings",
+//         "Labels",
+//         "ContentBidCriterionTypeGroup",
+//         "TrackingUrlTemplate",
+//         "UrlCustomParameters",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"Id", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "Id", "CampaignId", "CampaignName", "Name", "Status", "Settings", "Labels"
+//   "ContentBidCriterionTypeGroup", "TrackingUrlTemplate", "UrlCustomParameters"
+//
+// filterable fields are
+//   "Id", "CampaignId", "CampaignName", "Name", "Status", "Labels"
+//   "ContentBidCriterionTypeGroup", "TrackingUrlTemplate"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#get
+//
+func (s *AdGroupService) Get(selector Selector) (adGroups []AdGroup, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adGroupServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+	getResp := struct {
+		Size     int64     `xml:"rval>totalNumEntries"`
+		AdGroups []AdGroup `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+	return getResp.AdGroups, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove ad group's, returning the
+// modified ad group's.
+//
+// Example
+//
+//  ads, err := adGroupService.Mutate(
+//    gads.AdGroupOperations{
+//      "ADD": {
+//        gads.AdGroup{
+//          Name:       "my ad group ",
+//          Status:     "PAUSED",
+//          CampaignId:  campaignId,
+//          BiddingStrategyConfiguration: []gads.BiddingStrategyConfiguration{
+//            gads.BiddingStrategyConfiguration{
+//              StrategyType: "MANUAL_CPC",
+//              Bids: []gads.Bid{
+//                gads.Bid{
+//                  Type:   "CpcBid",
+//                  Amount: 10000,
+//                },
+//              },
+//            },
+//          },
+//        },
+//      },
+//      "SET": {
+//        modifiedAdGroup,
+//      },
+//      "REMOVE": {
+//        adGroupNeedingRemoval,
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#mutate
+//
+func (s *AdGroupService) Mutate(adGroupOperations AdGroupOperations) (adGroups []AdGroup, err error) {
+	type adGroupOperation struct {
+		Action  string  `xml:"operator"`
+		AdGroup AdGroup `xml:"operand"`
+	}
+	operations := []adGroupOperation{}
+	for action, adGroups := range adGroupOperations {
+		for _, adGroup := range adGroups {
+			operations = append(operations,
+				adGroupOperation{
+					Action:  action,
+					AdGroup: adGroup,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(adGroupServiceUrl, "mutate", mutation)
+	if err != nil {
+		return adGroups, err
+	}
+	mutateResp := struct {
+		AdGroups []AdGroup `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroups, err
+	}
+
+	return mutateResp.AdGroups, err
+}
+
+// MutateLabel allows you to add and removes labels from ad groups.
+//
+// Example
+//
+//  adGroups, err := adGroupService.MutateLabel(
+//    gads.AdGroupLabelOperations{
+//      "ADD": {
+//        gads.AdGroupLabel{AdGroupId: 3200, LabelId: 5353},
+//        gads.AdGroupLabel{AdGroupId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.AdGroupLabel{AdGroupId: 3653, LabelId: 5653},
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#mutateLabel
+//
+func (s *AdGroupService) MutateLabel(adGroupLabelOperations AdGroupLabelOperations) (adGroupLabels []AdGroupLabel, err error) {
+	type adGroupLabelOperation struct {
+		Action       string       `xml:"operator"`
+		AdGroupLabel AdGroupLabel `xml:"operand"`
+	}
+	operations := []adGroupLabelOperation{}
+	for action, adGroupLabels := range adGroupLabelOperations {
+		for _, adGroupLabel := range adGroupLabels {
+			operations = append(operations,
+				adGroupLabelOperation{
+					Action:       action,
+					AdGroupLabel: adGroupLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(adGroupServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return adGroupLabels, err
+	}
+	mutateResp := struct {
+		AdGroupLabels []AdGroupLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupLabels, err
+	}
+
+	return mutateResp.AdGroupLabels, err
+}
+
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupService#query
+//
+func (s *AdGroupService) Query(query string) (adGroups []AdGroup, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		adGroupServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+
+	getResp := struct {
+		Size     int64     `xml:"rval>totalNumEntries"`
+		AdGroups []AdGroup `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroups, totalCount, err
+	}
+	return getResp.AdGroups, getResp.Size, err
+
+}

--- a/v201705/ad_group_ad.go
+++ b/v201705/ad_group_ad.go
@@ -1,0 +1,465 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type AdGroupAdService struct {
+	Auth
+}
+
+type AppUrl struct {
+	Url    string `xml:"url"`
+	OsType string `xml:"osType"` // "OS_TYPE_IOS", "OS_TYPE_ANDROID", "UNKNOWN"
+}
+
+type TextAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Headline             string            `xml:"headline"`
+	Description1         string            `xml:"description1"`
+	Description2         string            `xml:"description2"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type ExpandedTextAd struct {
+	AdGroupId            int64                  `xml:"-"`
+	Id                   int64                  `xml:"id,omitempty"`
+	FinalUrls            []string               `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string               `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate  string                 `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters      `xml:"urlCustomParameters,omitempty"`
+	Type                 string                 `xml:"type,omitempty"`
+	HeadlinePart1        string                 `xml:"headlinePart1"`
+	HeadlinePart2        string                 `xml:"headlinePart2"`
+	Description          string                 `xml:"description"`
+	Path1                string                 `xml:"path1"`
+	Path2                string                 `xml:"path2"`
+	ExperimentData       *AdGroupExperimentData `xml:"-"`
+	Status               string                 `xml:"-"`
+	ApprovalStatus       string                 `xml:"-"`
+	Trademarks           []string               `xml:"-"`
+	DisapprovalReasons   []string               `xml:"-"`
+	TrademarkDisapproved bool                   `xml:"-"`
+	Labels               []Label                `xml:"-"`
+	BaseCampaignId       *int64                 `xml:"-"`
+	BaseAdGroupId        *int64                 `xml:"-"`
+}
+
+type ResponsiveDisplayAd struct {
+	AdGroupId            int64                 `xml:"-"`
+	Id                   int64                 `xml:"id,omitempty"`
+	FinalUrls            []string              `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string              `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate  string                `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters     `xml:"urlCustomParameters,omitempty"`
+	Type                 string                `xml:"type,omitempty"`
+	MarketingImage       Media                 `xml:"marketingImage"`
+	LogoImage            Media                 `xml:"logoImage"`
+	ShortHeadline        string                `xml:"shortHeadline"`
+	LongHeadline         string                `xml:"longHeadline"`
+	Description          string                `xml:"description"`
+	BusinessName         string                `xml:"businessName"`
+	ExperimentData       AdGroupExperimentData `xml:"-"`
+	Status               string                `xml:"-"`
+	ApprovalStatus       string                `xml:"-"`
+	Trademarks           []string              `xml:"-"`
+	DisapprovalReasons   []string              `xml:"-"`
+	TrademarkDisapproved bool                  `xml:"-"`
+	Labels               []Label               `xml:"-"`
+	BaseCampaignId       int64                 `xml:"-"`
+	BaseAdGroupId        int64                 `xml:"-"`
+}
+
+type AdGroupExperimentData struct {
+	ExperimentId          int64  `xml:"experimentId"`
+	ExperimentDeltaStatus string `xml:"experimentDeltaStatus"`
+	ExperimentDataStatus  string `xml:"experimentDataStatus"`
+}
+
+type ImageAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Image                int64             `xml:"imageId"`
+	Name                 string            `xml:"name"`
+	AdToCopyImageFrom    int64             `xml:"adToCopyImageFrom"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type MobileAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Headline             string            `xml:"headline"`
+	Description          string            `xml:"description"`
+	MarkupLanguages      []string          `xml:"markupLanguages"`
+	MobileCarriers       []string          `xml:"mobileCarriers"`
+	BusinessName         string            `xml:"businessName"`
+	CountryCode          string            `xml:"countryCode"`
+	PhoneNumber          string            `xml:"phoneNumber"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type TemplateElementField struct {
+	Name       string `xml:"name"`
+	Type       string `xml:"type"`
+	FieldText  string `xml:"fieldText"`
+	FieldMedia string `xml:"fieldMedia"`
+}
+
+type TemplateElement struct {
+	UniqueName string                 `xml:"uniqueName"`
+	Fields     []TemplateElementField `xml:"fields"`
+}
+
+type TemplateAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	TemplateId           int64             `xml:"templateId"`
+	AdUnionId            int64             `xml:"adUnionId>id"`
+	TemplateElements     []TemplateElement `xml:"templateElements"`
+	Dimensions           []Dimensions      `xml:"dimensions"`
+	Name                 string            `xml:"name"`
+	Duration             int64             `xml:"duration"`
+	originAdId           *int64            `xml:"originAdId"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+	Labels               []Label           `xml:"-"`
+}
+
+type DynamicSearchAd struct {
+	AdGroupId            int64             `xml:"-"`
+	Id                   int64             `xml:"id,omitempty"`
+	Url                  string            `xml:"url"`
+	DisplayUrl           string            `xml:"displayUrl"`
+	FinalUrls            []string          `xml:"finalUrls,omitempty"`
+	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
+	DevicePreference     int64             `xml:"devicePreference,omitempty"`
+	Status               string            `xml:"-"`
+	ApprovalStatus       string            `xml:"-"`
+	DisapprovalReasons   []string          `xml:"-"`
+	TrademarkDisapproved bool              `xml:"-"`
+}
+
+type ProductAd struct {
+	AdGroupId            int64    `xml:"-"`
+	Id                   int64    `xml:"id,omitempty"`
+	Type                 string   `xml:"type,omitempty"`
+	Status               string   `xml:"-"`
+	ApprovalStatus       string   `xml:"-"`
+	DisapprovalReasons   []string `xml:"-"`
+	TrademarkDisapproved bool     `xml:"-"`
+}
+
+type AdGroupAdOperations map[string]AdGroupAds
+
+func NewAdGroupAdService(auth *Auth) *AdGroupAdService {
+	return &AdGroupAdService{Auth: *auth}
+}
+
+func NewTextAd(adGroupId int64, url, displayUrl, headline, description1, description2, status string) TextAd {
+	return TextAd{
+		AdGroupId:    adGroupId,
+		Url:          url,
+		DisplayUrl:   displayUrl,
+		Headline:     headline,
+		Description1: description1,
+		Description2: description2,
+		Status:       status,
+	}
+}
+
+type AdGroupAdLabel struct {
+	AdGroupAdId int64 `xml:"adGroupAdId"`
+	LabelId     int64 `xml:"labelId"`
+}
+
+type AdGroupAdLabelOperations map[string][]AdGroupAdLabel
+
+type AdUrlUpgrade struct {
+	AdId                int64  `xml:"adId"`
+	FinalUrl            string `xml:"finalUrl"`
+	FinalMobileUrl      string `xml:"finalMobileUrl"`
+	TrackingUrlTemplate string `xml:"trackingUrlTemplate"`
+}
+
+// Get returns an array of ad's and the total number of ad's matching
+// the selector.
+//
+// Example
+//
+//   ads, totalCount, err := adGroupAdService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//         "Status",
+//         "AdGroupCreativeApprovalStatus",
+//         "AdGroupAdDisapprovalReasons",
+//         "AdGroupAdTrademarkDisapproved",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"AdGroupId", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "Id", "Url", "DisplayUrl", "CreativeFinalUrls", "CreativeFinalMobileUrls",
+//   "CreativeFinalAppUrls", "CreativeTrackingUrlTemplate", "CreativeUrlCustomParameters",
+//   "DevicePreference", "Status", "AdGroupCreativeApprovalStatus", "AdGroupAdDisapprovalReasons"
+//   "AdGroupAdTrademarkDisapproved", "Labels"
+//
+//   TextAd
+//     "Headline", "Description1", "Description2"
+//
+//   ImageAd
+//     "ImageCreativeName"
+//
+// filterable fields are
+//   "AdGroupId", "Id", "Url", "DisplayUrl", "CreativeFinalUrls", "CreativeFinalMobileUrls",
+//   "CreativeFinalAppUrls", "CreativeTrackingUrlTemplate", "CreativeUrlCustomParameters",
+//   "DevicePreference", "Status", "AdGroupCreativeApprovalStatus", "AdGroupAdDisapprovalReasons"
+//   "Labels"
+//
+//   TextAd specific fields
+//     "Headline", "Description1", "Description2"
+//
+//   ImageAd specific fields
+//     "ImageCreativeName"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#get
+//
+func (s AdGroupAdService) Get(selector Selector) (adGroupAds AdGroupAds, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adGroupAdServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroupAds, totalCount, err
+	}
+	getResp := struct {
+		Size       int64      `xml:"rval>totalNumEntries"`
+		AdGroupAds AdGroupAds `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupAds, totalCount, err
+	}
+	return getResp.AdGroupAds, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove ads, returning the
+// modified ads.
+//
+// Example
+//
+//  ads, err := adGroupAdService.Mutate(
+//    gads.AdGroupAdOperations{
+//      "ADD": {
+//        gads.NewTextAd(
+//          adGroup.Id,
+//          "https://classdo.com/en",
+//          "classdo.com",
+//          "test headline",
+//          "test line one",
+//          "test line two",
+//          "PAUSED",
+//        ),
+//      },
+//      "SET": {
+//        modifiedAd,
+//      },
+//      "REMOVE": {
+//        adNeedingRemoval,
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#mutate
+//
+func (s *AdGroupAdService) Mutate(adGroupAdOperations AdGroupAdOperations) (adGroupAds AdGroupAds, err error) {
+	type adGroupAdOperation struct {
+		Action    string     `xml:"operator"`
+		AdGroupAd AdGroupAds `xml:"operand"`
+	}
+	operations := []adGroupAdOperation{}
+	for action, adGroupAds := range adGroupAdOperations {
+		for _, adGroupAd := range adGroupAds {
+			operations = append(operations,
+				adGroupAdOperation{
+					Action:    action,
+					AdGroupAd: []interface{}{adGroupAd},
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupAdOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(adGroupAdServiceUrl, "mutate", mutation)
+	if err != nil {
+		return adGroupAds, err
+	}
+	mutateResp := struct {
+		AdGroupAds AdGroupAds `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupAds, err
+	}
+	return mutateResp.AdGroupAds, err
+}
+
+// MutateLabel allows you to add and removes labels from ads.
+//
+// Example
+//
+//  ads, err := adGroupAdService.MutateLabel(
+//    gads.AdGroupAdLabelOperations{
+//      "ADD": {
+//        gads.AdGroupAdLabel{AdGroupAdId: 3200, LabelId: 5353},
+//        gads.AdGroupAdLabel{AdGroupAdId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.AdGroupAdLabel{AdGroupAdId: 3653, LabelId: 5653},
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#mutateLabel
+//
+func (s *AdGroupAdService) MutateLabel(adGroupAdLabelOperations AdGroupAdLabelOperations) (adGroupAdLabels []AdGroupAdLabel, err error) {
+	type adGroupAdLabelOperation struct {
+		Action         string         `xml:"operator"`
+		AdGroupAdLabel AdGroupAdLabel `xml:"operand"`
+	}
+	operations := []adGroupAdLabelOperation{}
+	for action, adGroupAdLabels := range adGroupAdLabelOperations {
+		for _, adGroupAdLabel := range adGroupAdLabels {
+			operations = append(operations,
+				adGroupAdLabelOperation{
+					Action:         action,
+					AdGroupAdLabel: adGroupAdLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupAdLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(adGroupAdServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return adGroupAdLabels, err
+	}
+	mutateResp := struct {
+		AdGroupAdLabels []AdGroupAdLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupAdLabels, err
+	}
+
+	return mutateResp.AdGroupAdLabels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#query
+//
+func (s *AdGroupAdService) Query(query string) (adGroupAds AdGroupAds, totalCount int64, err error) {
+	return adGroupAds, totalCount, ERROR_NOT_YET_IMPLEMENTED
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#upgradeUrl
+//
+func (s *AdGroupAdService) UpgradeUrl(adUrlUpgrades []AdUrlUpgrade) (adGroupAds AdGroupAds, err error) {
+	return adGroupAds, ERROR_NOT_YET_IMPLEMENTED
+}

--- a/v201705/ad_group_ad.go
+++ b/v201705/ad_group_ad.go
@@ -29,9 +29,6 @@ type TextAd struct {
 	Description1         string            `xml:"description1"`
 	Description2         string            `xml:"description2"`
 	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
 	Labels               []Label           `xml:"-"`
 }
 
@@ -50,10 +47,6 @@ type ExpandedTextAd struct {
 	Path2                string                 `xml:"path2"`
 	ExperimentData       *AdGroupExperimentData `xml:"-"`
 	Status               string                 `xml:"-"`
-	ApprovalStatus       string                 `xml:"-"`
-	Trademarks           []string               `xml:"-"`
-	DisapprovalReasons   []string               `xml:"-"`
-	TrademarkDisapproved bool                   `xml:"-"`
 	Labels               []Label                `xml:"-"`
 	BaseCampaignId       *int64                 `xml:"-"`
 	BaseAdGroupId        *int64                 `xml:"-"`
@@ -75,10 +68,6 @@ type ResponsiveDisplayAd struct {
 	BusinessName         string                `xml:"businessName"`
 	ExperimentData       AdGroupExperimentData `xml:"-"`
 	Status               string                `xml:"-"`
-	ApprovalStatus       string                `xml:"-"`
-	Trademarks           []string              `xml:"-"`
-	DisapprovalReasons   []string              `xml:"-"`
-	TrademarkDisapproved bool                  `xml:"-"`
 	Labels               []Label               `xml:"-"`
 	BaseCampaignId       int64                 `xml:"-"`
 	BaseAdGroupId        int64                 `xml:"-"`
@@ -106,9 +95,6 @@ type ImageAd struct {
 	Name                 string            `xml:"name"`
 	AdToCopyImageFrom    int64             `xml:"adToCopyImageFrom"`
 	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
 	Labels               []Label           `xml:"-"`
 }
 
@@ -132,9 +118,6 @@ type MobileAd struct {
 	CountryCode          string            `xml:"countryCode"`
 	PhoneNumber          string            `xml:"phoneNumber"`
 	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
 	Labels               []Label           `xml:"-"`
 }
 
@@ -170,9 +153,6 @@ type TemplateAd struct {
 	Duration             int64             `xml:"duration"`
 	originAdId           *int64            `xml:"originAdId"`
 	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
 	Labels               []Label           `xml:"-"`
 }
 
@@ -189,9 +169,6 @@ type DynamicSearchAd struct {
 	Type                 string            `xml:"type,omitempty"`
 	DevicePreference     int64             `xml:"devicePreference,omitempty"`
 	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
 }
 
 type ProductAd struct {
@@ -199,9 +176,6 @@ type ProductAd struct {
 	Id                   int64    `xml:"id,omitempty"`
 	Type                 string   `xml:"type,omitempty"`
 	Status               string   `xml:"-"`
-	ApprovalStatus       string   `xml:"-"`
-	DisapprovalReasons   []string `xml:"-"`
-	TrademarkDisapproved bool     `xml:"-"`
 }
 
 type AdGroupAdOperations map[string]AdGroupAds

--- a/v201705/ad_group_ad_test.go
+++ b/v201705/ad_group_ad_test.go
@@ -1,0 +1,61 @@
+package v201705
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testAdGroupAdService(t *testing.T) (service *AdGroupAdService) {
+	return &AdGroupAdService{Auth: testAuthSetup(t)}
+}
+
+func TestAdGroupAd(t *testing.T) {
+	adGroup, cleanupAdGroup := testAdGroup(t)
+	defer cleanupAdGroup()
+
+	agas := testAdGroupAdService(t)
+	adGroupAds, err := agas.Mutate(
+		AdGroupAdOperations{
+			"ADD": {
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test headline "+rand_word(10), "test line one", "test line two", "PAUSED"),
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test   teStTo "+rand_word(10), "test line one", "test line two", "PAUSED"),
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test headline "+rand_word(10), "test line one", "test line two", "PAUSED"),
+				NewTextAd(adGroup.Id, "https://classdo.com/en", "classdo.com", "test headline "+rand_word(10), "test line one", "test line two", "PAUSED"),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, err = agas.Mutate(AdGroupAdOperations{"REMOVE": adGroupAds})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	adGroupIdStr := fmt.Sprintf("%d", adGroup.Id)
+	_, _, err = agas.Get(
+		Selector{
+			Fields: []string{
+				"AdGroupId",
+				"Id",
+				"Status",
+				"AdGroupCreativeApprovalStatus",
+				"AdGroupAdDisapprovalReasons",
+				"AdGroupAdTrademarkDisapproved",
+			},
+			Predicates: []Predicate{
+				{"AdGroupId", "EQUALS", []string{adGroupIdStr}},
+			},
+			Ordering: []OrderBy{
+				{"AdGroupId", "ASCENDING"},
+				{"Id", "ASCENDING"},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/v201705/ad_group_ads.go
+++ b/v201705/ad_group_ads.go
@@ -1,0 +1,217 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type AdGroupAds []interface{}
+
+func (a1 AdGroupAds) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	a := a1[0]
+	e.EncodeToken(start)
+	switch a.(type) {
+	case TextAd:
+		ad := a.(TextAd)
+		e.EncodeElement(ad.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+		e.EncodeElement(ad, xml.StartElement{
+			xml.Name{"", "ad"},
+			[]xml.Attr{
+				xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "TextAd"},
+			},
+		})
+		e.EncodeElement(ad.Status, xml.StartElement{Name: xml.Name{"", "status"}})
+		e.EncodeElement(ad.Labels, xml.StartElement{Name: xml.Name{"", "labels"}})
+	case ExpandedTextAd:
+		ad := a.(ExpandedTextAd)
+		e.EncodeElement(ad.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+		e.EncodeElement(ad, xml.StartElement{
+			xml.Name{"", "ad"},
+			[]xml.Attr{
+				xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "ExpandedTextAd"},
+			},
+		})
+		e.EncodeElement(ad.Status, xml.StartElement{Name: xml.Name{"", "status"}})
+		e.EncodeElement(ad.Labels, xml.StartElement{Name: xml.Name{"", "labels"}})
+	case ImageAd:
+		return ERROR_NOT_YET_IMPLEMENTED
+	case TemplateAd:
+		return ERROR_NOT_YET_IMPLEMENTED
+	default:
+		return fmt.Errorf("unknown Ad type -> %#v", start)
+	}
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	typeName := xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"}
+	var adGroupId int64
+	var status, approvalStatus string
+	var disapprovalReasons []string
+	var trademarkDisapproved bool
+	var labels []Label
+	var experimentData *AdGroupExperimentData
+	var trademarks []string
+	var baseCampaignId *int64
+	var baseAdGroupId *int64
+	var ad interface{}
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "adGroupId":
+				err := dec.DecodeElement(&adGroupId, &start)
+				if err != nil {
+					return err
+				}
+			case "ad":
+				typeName, err := findAttr(start.Attr, typeName)
+				if err != nil {
+					return err
+				}
+				fmt.Println(typeName)
+				switch typeName {
+				case "TextAd":
+					a := TextAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "ExpandedTextAd":
+					a := ExpandedTextAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "ImageAd":
+					a := ImageAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "TemplateAd":
+					a := TemplateAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+					ad = a
+				case "DynamicSearchAd":
+					a := DynamicSearchAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+				case "ProductAd":
+					a := ProductAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("unknown AdGroupCriterion -> %#v", start)
+				}
+			case "experimentData":
+				err := dec.DecodeElement(&experimentData, &start)
+				if err != nil {
+					return err
+				}
+			case "status":
+				err := dec.DecodeElement(&status, &start)
+				if err != nil {
+					return err
+				}
+			case "approvalStatus":
+				err := dec.DecodeElement(&approvalStatus, &start)
+				if err != nil {
+					return err
+				}
+			case "trademarks":
+				err := dec.DecodeElement(&trademarks, &start)
+				if err != nil {
+					return err
+				}
+			case "disapprovalReasons":
+				err := dec.DecodeElement(&disapprovalReasons, &start)
+				if err != nil {
+					return err
+				}
+			case "trademarkDisapproved":
+				err := dec.DecodeElement(&trademarkDisapproved, &start)
+				if err != nil {
+					return err
+				}
+			case "labels":
+				err := dec.DecodeElement(&labels, &start)
+				if err != nil {
+					return err
+				}
+			case "baseCampaignId":
+				err := dec.DecodeElement(&baseCampaignId, &start)
+				if err != nil {
+					return err
+				}
+			case "baseAdGroupId":
+				err := dec.DecodeElement(&baseAdGroupId, &start)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unknown AdGroupAd field -> %#v", tag)
+			}
+
+		}
+	}
+	switch a := ad.(type) {
+	case TextAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case ExpandedTextAd:
+		a.ExperimentData = experimentData
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.Trademarks = trademarks
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		a.Labels = labels
+		a.BaseCampaignId = baseCampaignId
+		a.BaseAdGroupId = baseAdGroupId
+		*aga = append(*aga, a)
+	case ImageAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case TemplateAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case DynamicSearchAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	case ProductAd:
+		a.Status = status
+		a.ApprovalStatus = approvalStatus
+		a.DisapprovalReasons = disapprovalReasons
+		a.TrademarkDisapproved = trademarkDisapproved
+		*aga = append(*aga, a)
+	}
+	return nil
+}

--- a/v201705/ad_group_bid_modifier.go
+++ b/v201705/ad_group_bid_modifier.go
@@ -1,0 +1,24 @@
+package v201705
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type AdGroupBidModifierService struct {
+	Auth
+}
+
+func NewAdGroupBidModifierService(auth *Auth) *AdGroupBidModifierService {
+	return &AdGroupBidModifierService{Auth: *auth}
+}
+
+/*
+type AdGroupBidModifier struct {
+  CampaignId        int64     `xml:"campaignId"`
+  AdGroupId         int64     `xml:"adGroupId"`
+  Criterion         Criterion `xml:"criterion"`
+  BidModifier       float64   `xml:"bidModifier"`
+  BidModifierSource string    `xml:"bidModifierSource"`
+}
+*/

--- a/v201705/ad_group_criterion.go
+++ b/v201705/ad_group_criterion.go
@@ -1,0 +1,339 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type AdGroupCriterionService struct {
+	Auth
+}
+
+func NewAdGroupCriterionService(auth *Auth) *AdGroupCriterionService {
+	return &AdGroupCriterionService{Auth: *auth}
+}
+
+type QualityInfo struct {
+	QualityScore int64 `xml:"qualityScore,omitempty"`
+}
+
+type CpcAmount struct {
+	MicroAmount int64 `xml:"microAmount,omitempty"`
+}
+
+type Cpc struct {
+	Amount *CpcAmount `xml:"amount,omitempty"`
+}
+
+type AdGroupCriterions []interface{}
+
+type AdGroupCriterionLabel struct {
+	AdGroupCriterionId int64 `xml:"adGroupCriterionId"`
+	LabelId            int64 `xml:"labelId"`
+}
+
+type AdGroupCriterionLabelOperations map[string][]AdGroupCriterionLabel
+
+func (agcs *AdGroupCriterions) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	adGroupCriterionType, err := findAttr(start.Attr, xml.Name{
+		Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return err
+	}
+	switch adGroupCriterionType {
+	case "BiddableAdGroupCriterion":
+		bagc := BiddableAdGroupCriterion{}
+		err := dec.DecodeElement(&bagc, &start)
+		if err != nil {
+			return err
+		}
+		*agcs = append(*agcs, bagc)
+	case "NegativeAdGroupCriterion":
+		nagc := NegativeAdGroupCriterion{}
+		err := dec.DecodeElement(&nagc, &start)
+		if err != nil {
+			return err
+		}
+		*agcs = append(*agcs, nagc)
+	default:
+		return fmt.Errorf("unknown AdGroupCriterion -> %#v", adGroupCriterionType)
+	}
+	return nil
+}
+
+type AdGroupCriterionOperations map[string]AdGroupCriterions
+
+// Get returns an array of AdGroupCriterion's and the total number of AdGroupCriterion's matching
+// the selector.
+//
+// Example
+//
+//   adGroupCriterions, totalCount, err := adGroupCriterionService.Get(
+//     Selector{
+//       Fields: []string{"Id","KeywordText","KeywordMatchType"},
+//       Predicates: []Predicate{
+//         {"AdGroupId", "EQUALS", []string{"432434"}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "CriterionUse", "Id", "CriteriaType", "Labels"
+//
+//   AgeRange
+//     "AgeRangeType",
+//
+//   AppPaymentModel
+//     "AppPaymentModelType",
+//
+//   CriterionUserInterest
+//     "UserInterestId", "UserInterestName",
+//
+//   CriterionUserList
+//     "UserListId", "UserListName", "UserListMembershipStatus"
+//
+//   Gender
+//     "GenderType"
+//
+//   Keyword
+//     "KeywordText", "KeywordMatchType"
+//
+//   MobileAppCategory
+//     "MobileAppCategoryId"
+//
+//   MobileApplication
+//     "DisplayName"
+//
+//   Placement
+//     "PlacementUrl"
+//
+//   Product
+//     "Text"
+//
+//   ProductPartition
+//     "PartitionType", "ParentCriterionId", "CaseValue"
+//
+//   Vertical
+//     "VerticalId", "VerticalParentId", "Path"
+//
+//   Webpage
+//     "Parameter", "CriteriaCoverage", "CriteriaSamples"
+//
+// filterable fields are
+//
+//   "AdGroupId", "CriterionUse", "Id", "CriteriaType", "Labels"
+//
+//   CriterionUserList
+//     "UserListMembershipStatus"
+//
+//   Keyword
+//     "KeywordText", "KeywordMatchType"
+//
+//   MobileApplication
+//     "DisplayName"
+//
+//   Placement
+//     "PlacementUrl"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#get
+//
+func (s AdGroupCriterionService) Get(selector Selector) (adGroupCriterions AdGroupCriterions, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adGroupCriterionServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+	getResp := struct {
+		Size              int64             `xml:"rval>totalNumEntries"`
+		AdGroupCriterions AdGroupCriterions `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+	return getResp.AdGroupCriterions, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove ad group criterion, returning the
+// modified ad group criterion.
+//
+// Example
+//
+//  ads, err := adGroupService.Mutate(
+//    gads.AdGroupCriterionOperations{
+//      "ADD": {
+//        BiddableAdGroupCriterion{
+//          AdGroupId:  adGroupId,
+//          Criterion:  gads.KeywordCriterion{Text: "test1", MatchType: "EXACT"},
+//          UserStatus: "PAUSED",
+//        },
+//        NegativeAdGroupCriterion{
+//          AdGroupId: adGroupId,
+//          Criterion: gads.KeywordCriterion{Text: "test4", MatchType: "BROAD"},
+//        },
+//      },
+//      "SET": {
+//        modifiedAdGroupCriterion,
+//      },
+//      "REMOVE": {
+//        adGroupCriterionNeedingRemoval,
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#mutate
+//
+func (s *AdGroupCriterionService) Mutate(adGroupCriterionOperations AdGroupCriterionOperations) (adGroupCriterions AdGroupCriterions, err error) {
+	type adGroupCriterionOperation struct {
+		Action           string      `xml:"operator"`
+		AdGroupCriterion interface{} `xml:"operand"`
+	}
+	operations := []adGroupCriterionOperation{}
+	for action, adGroupCriterions := range adGroupCriterionOperations {
+		for _, adGroupCriterion := range adGroupCriterions {
+			operations = append(operations,
+				adGroupCriterionOperation{
+					Action:           action,
+					AdGroupCriterion: adGroupCriterion,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupCriterionOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(adGroupCriterionServiceUrl, "mutate", mutation)
+	if err != nil {
+		return adGroupCriterions, err
+	}
+	mutateResp := struct {
+		AdGroupCriterions AdGroupCriterions `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupCriterions, err
+	}
+
+	return mutateResp.AdGroupCriterions, err
+}
+
+// MutateLabel allows you to add and removes labels from ad groups.
+//
+// Example
+//
+//  adGroupCriterions, err := adGroupCriterionService.MutateLabel(
+//    gads.AdGroupCriterionLabelOperations{
+//      "ADD": {
+//        gads.AdGroupCriterionLabel{AdGroupCriterionId: 3200, LabelId: 5353},
+//        gads.AdGroupCriterionLabel{AdGroupCriterionId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.AdGroupCriterionLabel{AdGroupCriterionId: 3653, LabelId: 5653},
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#mutateLabel
+//
+func (s *AdGroupCriterionService) MutateLabel(adGroupCriterionLabelOperations AdGroupCriterionLabelOperations) (adGroupCriterionLabels []AdGroupCriterionLabel, err error) {
+	type adGroupCriterionLabelOperation struct {
+		Action                string                `xml:"operator"`
+		AdGroupCriterionLabel AdGroupCriterionLabel `xml:"operand"`
+	}
+	operations := []adGroupCriterionLabelOperation{}
+	for action, adGroupCriterionLabels := range adGroupCriterionLabelOperations {
+		for _, adGroupCriterionLabel := range adGroupCriterionLabels {
+			operations = append(operations,
+				adGroupCriterionLabelOperation{
+					Action:                action,
+					AdGroupCriterionLabel: adGroupCriterionLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []adGroupCriterionLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(adGroupCriterionServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return adGroupCriterionLabels, err
+	}
+	mutateResp := struct {
+		AdGroupCriterionLabels []AdGroupCriterionLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adGroupCriterionLabels, err
+	}
+
+	return mutateResp.AdGroupCriterionLabels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupCriterionService#query
+//
+func (s *AdGroupCriterionService) Query(query string) (adGroupCriterions AdGroupCriterions, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		adGroupCriterionServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+
+	getResp := struct {
+		Size              int64             `xml:"rval>totalNumEntries"`
+		AdGroupCriterions AdGroupCriterions `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupCriterions, totalCount, err
+	}
+	return getResp.AdGroupCriterions, getResp.Size, err
+
+}

--- a/v201705/ad_group_criterion_test.go
+++ b/v201705/ad_group_criterion_test.go
@@ -1,0 +1,96 @@
+package v201705
+
+import (
+	"testing"
+	//	"encoding/xml"
+)
+
+func testAdGroupCriterionService(t *testing.T) (service *AdGroupCriterionService) {
+	return &AdGroupCriterionService{Auth: testAuthSetup(t)}
+}
+
+func TestAdGroupCriterion(t *testing.T) {
+	adGroup, cleanupAdGroup := testAdGroup(nil)
+	defer cleanupAdGroup()
+
+	agcs := testAdGroupCriterionService(t)
+	adGroupCriterions, err := agcs.Mutate(
+		AdGroupCriterionOperations{
+			"ADD": {
+				/*
+									NegativeAdGroupCriterion{
+					          AdGroupId: adGroup.Id,
+					          Criterion: AgeRangeCriterion{AgeRangeType:"AGE_RANGE_25_34"},
+					        },
+									NegativeAdGroupCriterion{
+					          AdGroupId: adGroup.Id,
+					          Criterion: GenderCriterion{},
+					        },
+									NewBiddableAdGroupCriterion{
+					          AdGroupId: adGroup.Id,
+					          Criterion: MobileAppCategoryCriterion{
+					            60000,"My Google Play Android Apps"
+					          }
+					        },
+				*/
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  KeywordCriterion{Text: "test1", MatchType: "EXACT"},
+					UserStatus: "PAUSED",
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  KeywordCriterion{Text: "test2", MatchType: "PHRASE"},
+					UserStatus: "PAUSED",
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  KeywordCriterion{Text: "test3", MatchType: "BROAD"},
+					UserStatus: "PAUSED",
+				},
+				NegativeAdGroupCriterion{
+					AdGroupId: adGroup.Id,
+					Criterion: KeywordCriterion{Text: "test4", MatchType: "BROAD"},
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId:  adGroup.Id,
+					Criterion:  PlacementCriterion{Url: "https://classdo.com"},
+					UserStatus: "PAUSED",
+				},
+				// NewBiddableAdGroupCriterion(adGroup.Id, NewUserInterestCriterion()),
+				// NewBiddableAdGroupCriterion(adGroup.Id, NewUserListCriterion()),
+				// NewBiddableAdGroupCriterion(adGroup.Id, NewVerticalCriterion(0, 0, []string{"Pets & Anamals","Pets","Dogs"})),
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroup.Id,
+					Criterion: WebpageCriterion{
+						Parameter: WebpageParameter{
+							CriterionName: "test criterion",
+							Conditions: []WebpageCondition{
+								WebpageCondition{
+									Operand:  "URL",
+									Argument: "example.com",
+								},
+							},
+						},
+					},
+					UserStatus: "PAUSED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%#v", adGroupCriterions)
+
+	defer func() {
+		_, err = agcs.Mutate(AdGroupCriterionOperations{"REMOVE": adGroupCriterions})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	/*
+	   reqBody, err := xml.MarshalIndent(adGroupCriterions,"  ", "  ")
+	   t.Fatalf("%s\n",reqBody)
+	*/
+}

--- a/v201705/ad_group_extension.go
+++ b/v201705/ad_group_extension.go
@@ -1,0 +1,96 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService#query
+type AdGroupExtensionSettingService struct {
+	Auth
+}
+
+func NewAdGroupExtensionSettingService(auth *Auth) *AdGroupExtensionSettingService {
+	return &AdGroupExtensionSettingService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.AdGroupExtensionSetting
+// An AdGroupExtensionSetting is used to add or modify extensions being served for the specified ad group.
+type AdGroupExtensionSetting struct {
+	AdGroupId        int64            `xml:"https://adwords.google.com/api/adwords/cm/v201705 adGroupId,omitempty"`
+	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201705 extensionType,omitempty"`
+	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201705 extensionSetting,omitempty"`
+}
+
+type AdGroupExtensionSettingOperations map[string][]AdGroupExtensionSetting
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService#query
+func (s *AdGroupExtensionSettingService) Query(query string) (settings []AdGroupExtensionSetting, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		adGroupExtensionSettingServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	getResp := struct {
+		Size     int64                     `xml:"rval>totalNumEntries"`
+		Settings []AdGroupExtensionSetting `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return
+	}
+	return getResp.Settings, getResp.Size, err
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService#mutate
+func (s *AdGroupExtensionSettingService) Mutate(settingsOperations AdGroupExtensionSettingOperations) (settings []AdGroupExtensionSetting, err error) {
+	type settingOperations struct {
+		Action  string                  `xml:"operator"`
+		Setting AdGroupExtensionSetting `xml:"operand"`
+	}
+	operations := []settingOperations{}
+	for action, settings := range settingsOperations {
+		for _, setting := range settings {
+			operations = append(operations,
+				settingOperations{
+					Action:  action,
+					Setting: setting,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []settingOperations `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+
+	respBody, err := s.Auth.request(adGroupExtensionSettingServiceUrl, "mutate", mutation)
+	if err != nil {
+		return settings, err
+	}
+	mutateResp := struct {
+		Settings []AdGroupExtensionSetting `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal(respBody, &mutateResp)
+	if err != nil {
+		return settings, err
+	}
+
+	return mutateResp.Settings, err
+}

--- a/v201705/ad_group_feed.go
+++ b/v201705/ad_group_feed.go
@@ -1,0 +1,50 @@
+package v201705
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type AdGroupFeedService struct {
+	Auth
+}
+
+func NewAdGroupFeedService(auth *Auth) *AdGroupFeedService {
+	return &AdGroupFeedService{Auth: *auth}
+}
+
+type AdGroupFeedOperations struct {
+}
+
+type AdGroupFeed struct {
+}
+
+// Get is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#get
+//
+func (s AdGroupFeedService) Get(selector Selector) (adGroupFeeds []AdGroupFeed, err error) {
+	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
+}
+
+// Mutate is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#mutate
+//
+func (s *AdGroupFeedService) Mutate(adGroupFeedOperations AdGroupFeedOperations) (adGroupFeeds []AdGroupFeed, err error) {
+	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#query
+//
+func (s *AdGroupFeedService) Query(query string) (adGroupFeeds []AdGroupFeed, err error) {
+	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
+}

--- a/v201705/ad_group_test.go
+++ b/v201705/ad_group_test.go
@@ -1,0 +1,79 @@
+package v201705
+
+import (
+	"testing"
+	//  "encoding/xml"
+)
+
+func testAdGroupService(t *testing.T) (service *AdGroupService) {
+	return &AdGroupService{Auth: testAuthSetup(t)}
+}
+
+func testAdGroup(t *testing.T) (AdGroup, func()) {
+	campaign, cleanupCampaign := testCampaign(t)
+	ags := testAdGroupService(t)
+	adGroups, err := ags.Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       "test ad group " + rand_str(10),
+					Status:     "PAUSED",
+					CampaignId: campaign.Id,
+					BiddingStrategyConfiguration: []BiddingStrategyConfiguration{
+						BiddingStrategyConfiguration{
+							StrategyType: "MANUAL_CPC",
+							Bids: []Bid{
+								Bid{
+									Type:   "CpcBid",
+									Amount: 10000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAdGroup := func() {
+		adGroups[0].Status = "REMOVED"
+		_, err = ags.Mutate(AdGroupOperations{"SET": adGroups})
+		if err != nil {
+			t.Error(err)
+		}
+		cleanupCampaign()
+	}
+	return adGroups[0], cleanupAdGroup
+}
+
+func TestAdGroup(t *testing.T) {
+	campaign, cleanupCampaign := testCampaign(t)
+	defer cleanupCampaign()
+
+	ags := testAdGroupService(t)
+	adGroups, err := ags.Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       "test ad group " + rand_str(10),
+					Status:     "PAUSED",
+					CampaignId: campaign.Id,
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		adGroups[0].Status = "REMOVED"
+		_, err = ags.Mutate(AdGroupOperations{"SET": adGroups})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+}

--- a/v201705/ad_param.go
+++ b/v201705/ad_param.go
@@ -1,0 +1,27 @@
+package v201705
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type AdParamService struct {
+	Auth
+}
+
+type AdParam struct {
+}
+
+func NewAdParamService(auth *Auth) *AdParamService {
+	return &AdParamService{Auth: *auth}
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/AdParamService#get
+//
+func (s AdParamService) Get(selector Selector) (adParams []AdParam, err error) {
+	return adParams, ERROR_NOT_YET_IMPLEMENTED
+}

--- a/v201705/adwords_user_list.go
+++ b/v201705/adwords_user_list.go
@@ -1,0 +1,382 @@
+package v201705
+
+import (
+	sha256 "crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"io"
+)
+
+type AdwordsUserListService struct {
+	Auth
+}
+
+func NewAdwordsUserListService(auth *Auth) *AdwordsUserListService {
+	return &AdwordsUserListService{Auth: *auth}
+}
+
+type UserListLogicalRule struct {
+	Operator     string     `xml:"operator"` // "ALL", "ANY", "NONE", "UNKNOWN"
+	RuleOperands []UserList `xml:"ruleOperands"`
+}
+
+type UserListConversionType struct {
+	Id       *int64
+	Name     string
+	Category *string `xml:"category"` // "BOOMERANG_EVENT", "OTHER"
+}
+
+// Rule structs
+type DateRuleItem struct {
+	Key   string `xml:"key>name"`
+	Op    string `xml:"op"` // "UNKNOWN", "EQUALS", "NOT_EQUAL", "BEFORE", "AFTER"
+	Value string `xml:"string"`
+}
+
+type NumberRuleItem struct {
+	Key   string `xml:"key>name"`
+	Op    string `xml:"op"` // "UNKNOWN", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "EQUALS", "NOT_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL"
+	Value int64  `xml:"value"`
+}
+
+type StringRuleItem struct {
+	Key   string `xml:"key>name"`
+	Op    string `xml:"op"` // "UNKNOWN", "CONTAINS", "EQUALS", "STARTS_WITH", "ENDS_WITH", "NOT_EQUAL", "NOT_CONTAIN", "NOT_START_WITH", "NOT_END_WITH"
+	Value string `xml:"string"`
+}
+
+type RuleItemGroup struct {
+	Items []interface{} `xml:"items"`
+}
+
+type Rule struct {
+	Groups []RuleItemGroup `xml:"groups"`
+}
+
+type UserListOperations struct {
+	XMLName    xml.Name
+	Operations []Operation `xml:"operations"`
+}
+
+type MutateMembersOperations struct {
+	XMLName    xml.Name
+	Operations []Operation `xml:"operations"`
+}
+
+type MutateMembersOperand struct {
+	UserListId int64    `xml:"userListId"`
+	DataType   string   `xml:"dataType"`
+	RemoveAll  *bool    `xml:"removeAll"`
+	Members    []string `xml:"members"`
+}
+
+type UserList struct {
+	Id                    int64   `xml:"id,omitempty"`
+	Readonly              *bool   `xml:"isReadOnly"`
+	Name                  string  `xml:"name"`
+	Description           string  `xml:"description"`
+	Status                string  `xml:"status"` // membership status "OPEN", "CLOSED"
+	IntegrationCode       string  `xml:"integrationCode"`
+	AccessReason          string  `xml:"accessReason"`          // account access resson "OWNER", "SHARED", "LICENSED", "SUBSCRIBED"
+	AccountUserListStatus string  `xml:"accountUserListStatus"` // if share is still active "ACTIVE", "INACTIVE"
+	MembershipLifeSpan    int64   `xml:"membershipLifeSpan"`    // number of days cookie stays on list
+	Size                  *int64  `xml:"size,omitempty"`
+	SizeRange             *string `xml:"sizeRange,omitempty"`          // size range "LESS_THEN_FIVE_HUNDRED","LESS_THAN_ONE_THOUSAND", "ONE_THOUSAND_TO_TEN_THOUSAND","TEN_THOUSAND_TO_FIFTY_THOUSAND","FIFTY_THOUSAND_TO_ONE_HUNDRED_THOUSAND","ONE_HUNDRED_THOUSAND_TO_THREE_HUNDRED_THOUSAND","THREE_HUNDRED_THOUSAND_TO_FIVE_HUNDRED_THOUSAND","FIVE_HUNDRED_THOUSAND_TO_ONE_MILLION","ONE_MILLION_TO_TWO_MILLION","TWO_MILLION_TO_THREE_MILLION","THREE_MILLION_TO_FIVE_MILLION","FIVE_MILLION_TO_TEN_MILLION","TEN_MILLION_TO_TWENTY_MILLION","TWENTY_MILLION_TO_THIRTY_MILLION","THIRTY_MILLION_TO_FIFTY_MILLION","OVER_FIFTY_MILLION"
+	SizeForSearch         *int64  `xml:"sizeForSearch,omitempty"`      // estimated number of google.com users in this group
+	SizeRangeForSearch    *string `xml:"sizeRangeForSearch,omitempty"` // same values as size range but for search
+	ListType              *string `xml:"sizeType,omitempty"`           // one of "UNKNOWN", "REMARKETING", "LOGICAL", "EXTERNAL_REMARKETING", "RULE_BASED", "SIMILAR"
+
+	// LogicalUserList
+	LogicalRules *[]UserListLogicalRule `xml:"rules,omitempty"`
+
+	// BasicUserList
+	ConversionTypes *[]UserListConversionType `xml:"conversionTypes"`
+
+	// RuleUserList
+	Rule      *Rule   `xml:"rule,omitempty"`
+	StartDate *string `xml:"startDate,omitempty"`
+	EndDate   *string `xml:"endDate,omitempty"`
+
+	// SimilarUserList
+	SeedUserListId          *int64  `xml:"seedUserListId,omitempty"`
+	SeedUserListName        *string `xml:"seedUserListName,omitempty"`
+	SeedUserListDescription *string `xml:"seedUserListDescription,omitempty"`
+	SeedUserListStatus      *string `xml:"seedUserListStatus,omitempty"`
+	SeedListSize            *int64  `xml:"seedListSize,omitempty"`
+
+	// CrmBasedUserList
+	OptOutLink *string `xml:"optOutLink,omitempty"`
+
+	// Keep track of xsi:type for mutate and mutateMembers
+	Xsi_type string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+}
+
+// DoubleClick platform user list mapped to AdWords
+//func NewExternalRemarketingUserList() (adwordsUserList UserList) {
+//}
+
+//
+func NewLogicalUserList(name, description, status, integrationCode string, membershipLifeSpan int64, logicalRules []UserListLogicalRule) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		LogicalRules:       &logicalRules,
+		Xsi_type:           "LogicalUserList",
+	}
+}
+
+func NewBasicUserList(name, description, status, integrationCode string, membershipLifeSpan int64, conversionTypes []UserListConversionType) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		ConversionTypes:    &conversionTypes,
+		Xsi_type:           "BasicUserList",
+	}
+}
+
+func NewDateSpecificRuleUserList(name, description, status, integrationCode string, membershipLifeSpan int64, rule Rule, startDate, endDate string) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		Rule:               &rule,
+		StartDate:          &startDate,
+		EndDate:            &endDate,
+		Xsi_type:           "DateSpecificRuleUserList",
+	}
+}
+
+func NewExpressionRuleUserList(name, description, status, integrationCode string, membershipLifeSpan int64, rule Rule) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		Rule:               &rule,
+		Xsi_type:           "ExpressionRuleUserList",
+	}
+}
+
+func NewSimilarUserList(name, description, status, integrationCode string, membershipLifeSpan int64) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		Status:             status,
+		IntegrationCode:    integrationCode,
+		MembershipLifeSpan: membershipLifeSpan,
+		Xsi_type:           "SimilarUserList",
+	}
+}
+
+func NewCrmBasedUserList(name, description string, membershipLifeSpan int64, optOutLink string) (adwordsUserList UserList) {
+	return UserList{
+		Name:               name,
+		Description:        description,
+		MembershipLifeSpan: membershipLifeSpan,
+		OptOutLink:         &optOutLink,
+		Xsi_type:           "CrmBasedUserList",
+	}
+}
+
+func NewMutateMembersOperand() *MutateMembersOperand {
+	return &MutateMembersOperand{DataType: "EMAIL_SHA256"}
+}
+
+// Get returns an array of adwords user lists and the total number of adwords user lists matching
+// the selector.
+//
+// Example
+//
+//   ads, totalCount, err := adwordsUserListService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "Id",
+//         "Name",
+//         "Status",
+//         "Labels",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"Id", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "Id", "IsReadOnly", "Name", "Description", "Status", "IntegrationCode", "AccessReason",
+//   "AccountUserListStatus", "MembershipLifeSpan", "Size", "SizeRange", "SizeForSearch",
+//   "SizeRangeForSearch", "ListType"
+//
+//   BasicUserList
+//     "ConversionType"
+//
+//   LogicalUserList
+//     "Rules"
+//
+//   SimilarUserList
+//     "SeedUserListId", "SeedUserListName", "SeedUserListDescription", "SeedUserListStatus",
+//     "SeedListSize"
+//
+// filterable fields are
+//   "Id", "Name", "Status", "IntegrationCode", "AccessReason", "AccountUserListStatus",
+//   "MembershipLifeSpan", "Size", "SizeForSearch", "ListType"
+//
+//   SimilarUserList
+//     "SeedUserListId", "SeedListSize"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/AdwordsUserListService#get
+//
+func (s AdwordsUserListService) Get(selector Selector) (userLists []UserList, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		adwordsUserListServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return userLists, err
+	}
+	getResp := struct {
+		Size      int64      `xml:"rval>totalNumEntries"`
+		UserLists []UserList `xml:"rval>entries"`
+	}{}
+	fmt.Printf("%s\n", respBody)
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return userLists, err
+	}
+	return getResp.UserLists, err
+}
+
+// Mutate adds/sets a collection of user lists. Returns a list of User Lists
+//
+// Example
+// 	auls := gads.NewAdwordsUserListService(&config.Auth)
+//
+//	crmList := gads.NewCrmBasedUserList("Test List", "Just a list to test with", 0, "http://mytest.com/optout")
+//
+//	ops := gads.UserListOperations{
+//		Operations: []gads.Operation{
+//			gads.Operation{
+//				Operator: "ADD",
+//				Operand: crmList,
+//			},
+//		},
+//	}
+//
+//	resp, err := auls.Mutate(ops)
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/AdwordsUserListService#mutate
+//
+func (s *AdwordsUserListService) Mutate(userListOperations UserListOperations) (adwordsUserLists []UserList, err error) {
+
+	userListOperations.XMLName = xml.Name{
+		Space: baseRemarketingUrl,
+		Local: "mutate",
+	}
+
+	respBody, err := s.Auth.request(adwordsUserListServiceUrl, "mutate", userListOperations)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+	mutateResp := struct {
+		AdwordsUserLists []UserList `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+
+	return mutateResp.AdwordsUserLists, err
+}
+
+// Mutate adds/removes members/emails to specified user list.
+// Note: Only 1 operation per userListId
+//
+// Example
+// 	mmo := gads.NewMutateMembersOperand()
+// 	mmo.UserListId = resp[0].Id
+
+// 	var members []string
+// 	members = append(members,"brian@test.com")
+// 	members = append(members,"test@test.com")
+
+// 	mmo.Members = members
+
+// 	mutateMembersOperations := gads.MutateMembersOperations{
+// 		Operations: []gads.Operation{
+// 			gads.Operation{
+// 				Operator: "ADD",
+// 				Operand: mmo,
+// 			},
+// 		},
+// 	}
+//
+// 	auls.MutateMembers(mutateMembersOperations)
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/AdwordsUserListService#mutateMembers
+//
+func (s *AdwordsUserListService) MutateMembers(mutateMembersOperations MutateMembersOperations) (adwordsUserLists []UserList, err error) {
+	mutateMembersOperations.XMLName = xml.Name{
+		Space: baseRemarketingUrl,
+		Local: "mutateMembers",
+	}
+
+	respBody, err := s.Auth.request(adwordsUserListServiceUrl, "mutateMembers", mutateMembersOperations)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+	mutateResp := struct {
+		AdwordsUserLists []UserList `xml:"rval>userLists"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return adwordsUserLists, err
+	}
+
+	return mutateResp.AdwordsUserLists, err
+}
+
+func (mmo MutateMembersOperand) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+
+	mmo.encodeEmails()
+
+	e.EncodeToken(start)
+	e.EncodeElement(&mmo.UserListId, xml.StartElement{Name: xml.Name{baseRemarketingUrl, "userListId"}})
+	e.EncodeElement(&mmo.DataType, xml.StartElement{Name: xml.Name{baseRemarketingUrl, "dataType"}})
+	e.EncodeElement(&mmo.Members, xml.StartElement{Name: xml.Name{baseRemarketingUrl, "members"}})
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (mmo *MutateMembersOperand) encodeEmails() {
+
+	for key, value := range mmo.Members {
+		h256 := sha256.New()
+		io.WriteString(h256, value)
+		mmo.Members[key] = fmt.Sprintf("%x", h256.Sum(nil))
+	}
+}

--- a/v201705/base.go
+++ b/v201705/base.go
@@ -1,0 +1,280 @@
+package v201705
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+const (
+	version               = "v201705"
+	rootUrl               = "https://adwords.google.com/api/adwords/cm/"
+	baseUrl               = "https://adwords.google.com/api/adwords/cm/" + version
+	rootMcmUrl            = "https://adwords.google.com/api/adwords/mcm/"
+	baseMcmUrl            = "https://adwords.google.com/api/adwords/mcm/" + version
+	rootRemarketingUrl    = "https://adwords.google.com/api/adwords/rm/"
+	baseRemarketingUrl    = "https://adwords.google.com/api/adwords/rm/" + version
+	rootReportDownloadUrl = "https://adwords.google.com/api/adwords/reportdownload/"
+	baseReportDownloadUrl = "https://adwords.google.com/api/adwords/reportdownload/" + version
+	rootTrafficUrl        = "https://adwords.google.com/api/adwords/o/"
+	baseTrafficUrl        = "https://adwords.google.com/api/adwords/o/" + version
+)
+
+type ServiceUrl struct {
+	Url  string
+	Name string
+}
+
+// exceptions
+var (
+	ERROR_NOT_YET_IMPLEMENTED = fmt.Errorf("Not yet implemented")
+)
+
+var (
+
+	// service urls
+	adGroupAdServiceUrl               = ServiceUrl{baseUrl, "AdGroupAdService"}
+	adGroupBidModifierServiceUrl      = ServiceUrl{baseUrl, "AdGroupBidModifierService"}
+	adGroupCriterionServiceUrl        = ServiceUrl{baseUrl, "AdGroupCriterionService"}
+	adGroupExtensionSettingServiceUrl = ServiceUrl{baseUrl, "AdGroupExtensionSettingService"}
+	adGroupFeedServiceUrl             = ServiceUrl{baseUrl, "AdGroupFeedService"}
+	adGroupServiceUrl                 = ServiceUrl{baseUrl, "AdGroupService"}
+	adParamServiceUrl                 = ServiceUrl{baseUrl, "AdParamService"}
+	adwordsUserListServiceUrl         = ServiceUrl{baseRemarketingUrl, "AdwordsUserListService"}
+	batchJobServiceUrl                = ServiceUrl{baseUrl, "BatchJobService"}
+	biddingStrategyServiceUrl         = ServiceUrl{baseUrl, "BiddingStrategyService"}
+	budgetOrderServiceUrl             = ServiceUrl{baseUrl, "BudgetOrderService"}
+	budgetServiceUrl                  = ServiceUrl{baseUrl, "BudgetService"}
+	campaignExtensionSettingUrl       = ServiceUrl{baseUrl, "CampaignExtensionSettingService"}
+	campaignCriterionServiceUrl       = ServiceUrl{baseUrl, "CampaignCriterionService"}
+	campaignFeedServiceUrl            = ServiceUrl{baseUrl, "CampaignFeedService"}
+	campaignServiceUrl                = ServiceUrl{baseUrl, "CampaignService"}
+	campaignSharedSetServiceUrl       = ServiceUrl{baseUrl, "CampaignSharedSetService"}
+	constantDataServiceUrl            = ServiceUrl{baseUrl, "ConstantDataService"}
+	conversionTrackerServiceUrl       = ServiceUrl{baseUrl, "ConversionTrackerService"}
+	customerFeedServiceUrl            = ServiceUrl{baseUrl, "CustomerFeedService"}
+	customerServiceUrl                = ServiceUrl{baseMcmUrl, "CustomerService"}
+	customerSyncServiceUrl            = ServiceUrl{baseUrl, "CustomerSyncService"}
+	dataServiceUrl                    = ServiceUrl{baseUrl, "DataService"}
+	experimentServiceUrl              = ServiceUrl{baseUrl, "ExperimentService"}
+	feedItemServiceUrl                = ServiceUrl{baseUrl, "FeedItemService"}
+	feedMappingServiceUrl             = ServiceUrl{baseUrl, "FeedMappingService"}
+	feedServiceUrl                    = ServiceUrl{baseUrl, "FeedService"}
+	geoLocationServiceUrl             = ServiceUrl{baseUrl, "GeoLocationService"}
+	labelServiceUrl                   = ServiceUrl{baseUrl, "LabelService"}
+	locationCriterionServiceUrl       = ServiceUrl{baseUrl, "LocationCriterionService"}
+	managedCustomerServiceUrl         = ServiceUrl{baseMcmUrl, "ManagedCustomerService"}
+	mediaServiceUrl                   = ServiceUrl{baseUrl, "MediaService"}
+	mutateJobServiceUrl               = ServiceUrl{baseUrl, "MutateJobService"}
+	offlineConversionFeedServiceUrl   = ServiceUrl{baseUrl, "OfflineConversionFeedService"}
+	reportDefinitionServiceUrl        = ServiceUrl{baseUrl, "ReportDefinitionService"}
+	reportDownloadServiceUrl          = ServiceUrl{baseReportDownloadUrl, ""}
+	sharedCriterionServiceUrl         = ServiceUrl{baseUrl, "SharedCriterionService"}
+	sharedSetServiceUrl               = ServiceUrl{baseUrl, "SharedSetService"}
+	targetingIdeaServiceUrl           = ServiceUrl{baseTrafficUrl, "TargetingIdeaService"}
+	trafficEstimatorServiceUrl        = ServiceUrl{baseTrafficUrl, "TrafficEstimatorService"}
+)
+
+func (s ServiceUrl) String() string {
+	if s.Name != "" {
+		return s.Url + "/" + s.Name
+	}
+	return s.Url
+}
+
+type Auth struct {
+	CustomerId     string
+	DeveloperToken string
+	UserAgent      string
+	PartialFailure bool
+	Testing        *testing.T   `json:"-"`
+	Client         *http.Client `json:"-"`
+}
+
+//
+// Selector structs
+//
+type DateRange struct {
+	Min string `xml:"min"`
+	Max string `xml:"max"`
+}
+
+type Predicate struct {
+	Field    string   `xml:"field"`
+	Operator string   `xml:"operator"`
+	Values   []string `xml:"values"`
+}
+
+type OrderBy struct {
+	Field     string `xml:"field"`
+	SortOrder string `xml:"sortOrder"`
+}
+
+type Paging struct {
+	Offset int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 startIndex"`
+	Limit  int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 numberResults"`
+}
+
+type Selector struct {
+	XMLName    xml.Name
+	Fields     []string    `xml:"fields"`
+	Predicates []Predicate `xml:"predicates"`
+	DateRange  *DateRange  `xml:"dateRange,omitempty"`
+	Ordering   []OrderBy   `xml:"ordering"`
+	Paging     *Paging     `xml:"paging,omitempty"`
+}
+
+type AWQLQuery struct {
+	XMLName xml.Name
+	Query   string `xml:"query"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.DayOfWeek
+// Days of the week.
+// MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+type DayOfWeek string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.MinuteOfHour
+// Minutes in an hour. Currently only 0, 15, 30, and 45 are supported
+// ZERO, FIFTEEN, THIRTY, FORTY_FIVE
+type MinuteOfHour string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.GeoRestriction
+// A restriction used to determine if the request context's geo should be matched.
+// UNKNOWN, LOCATION_OF_PRESENCE
+type GeoRestriction string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.PolicyData
+// Approval and policy information attached to an entity.
+type PolicyData struct {
+	DisapprovalReasons []DisapprovalReason `xml:"https://adwords.google.com/api/adwords/cm/v201705 disapprovalReasons,omitempty"`
+	PolicyDataType     string              `xml:"https://adwords.google.com/api/adwords/cm/v201705 PolicyData.Type,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.DisapprovalReason
+// Container for information about why an AdWords entity was disapproved.
+type DisapprovalReason struct {
+	ShortName string `xml:"https://adwords.google.com/api/adwords/cm/v201705 shortName,omitempty"`
+}
+
+// error parsers
+func selectorError() (err error) {
+	return err
+}
+
+func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}) (respBody []byte, err error) {
+
+	type devToken struct {
+		XMLName xml.Name
+	}
+	type soapReqHeader struct {
+		XMLName          xml.Name
+		UserAgent        string `xml:"userAgent"`
+		DeveloperToken   string `xml:"developerToken"`
+		ClientCustomerId string `xml:"clientCustomerId,omitempty"`
+		PartialFailure   bool   `xml:"partialFailure,omitempty"`
+	}
+
+	type soapReqBody struct {
+		Body interface{}
+	}
+
+	type soapReqEnvelope struct {
+		XMLName xml.Name
+		Header  soapReqHeader `xml:"Header>RequestHeader"`
+		Body    soapReqBody   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
+	}
+
+	reqHead := soapReqHeader{
+		XMLName:          xml.Name{serviceUrl.Url, "RequestHeader"},
+		UserAgent:        a.UserAgent,
+		DeveloperToken:   a.DeveloperToken,
+		ClientCustomerId: a.CustomerId,
+	}
+
+	// https://developers.google.com/adwords/api/docs/guides/partial-failure
+	if a.PartialFailure {
+		reqHead.PartialFailure = true
+	}
+
+	reqBody, err := xml.MarshalIndent(
+		soapReqEnvelope{
+			XMLName: xml.Name{"http://schemas.xmlsoap.org/soap/envelope/", "Envelope"},
+			Header:  reqHead,
+			Body:    soapReqBody{body},
+		},
+		"  ", "  ")
+	if err != nil {
+		return []byte{}, err
+	}
+
+	req, err := http.NewRequest("POST", serviceUrl.String(), bytes.NewReader(reqBody))
+	req.Header.Add("Accept", "text/xml")
+	req.Header.Add("Accept", "multipart/*")
+	req.Header.Add("Content-Type", "text/xml;charset=UTF-8")
+	contentLength := fmt.Sprintf("%d", len(reqBody))
+	req.Header.Add("Content-length", contentLength)
+	req.Header.Add("SOAPAction", action)
+	if a.Testing != nil {
+		a.Testing.Logf("request ->\n%s\n%#v\n%s\n", req.URL.String(), req.Header, string(reqBody))
+	}
+
+	// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+	if level := os.Getenv("DEBUG"); level != "" {
+		fmt.Printf("request ->\n%s\n%#v\n%s\n", req.URL.String(), req.Header, string(reqBody))
+	}
+
+	resp, err := a.Client.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err = ioutil.ReadAll(resp.Body)
+
+	// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+	if level := os.Getenv("DEBUG"); level != "" {
+		fmt.Printf("response ->\n%s\n", string(respBody))
+	}
+
+	if a.Testing != nil {
+		a.Testing.Logf("respBody ->\n%s\n%s\n", string(respBody), resp.Status)
+	}
+
+	type soapRespHeader struct {
+		RequestId    string `xml:"requestId"`
+		ServiceName  string `xml:"serviceName"`
+		MethodName   string `xml:"methodName"`
+		Operations   int64  `xml:"operations"`
+		ResponseTime int64  `xml:"responseTime"`
+	}
+
+	type soapRespBody struct {
+		Response []byte `xml:",innerxml"`
+	}
+
+	soapResp := struct {
+		XMLName xml.Name       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+		Header  soapRespHeader `xml:"Header>RequestHeader"`
+		Body    soapRespBody   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &soapResp)
+	if err != nil {
+		return respBody, err
+	}
+	if resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 405 || resp.StatusCode == 500 {
+		fault := Fault{}
+		fmt.Printf("unknown error ->\n%s\n", string(soapResp.Body.Response))
+		err = xml.Unmarshal(soapResp.Body.Response, &fault)
+		if err != nil {
+			return respBody, err
+		}
+		return soapResp.Body.Response, &fault.Errors
+	}
+	return soapResp.Body.Response, err
+}

--- a/v201705/base_test.go
+++ b/v201705/base_test.go
@@ -1,0 +1,36 @@
+package v201705
+
+import (
+	"crypto/rand"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+func rand_str(str_size int) string {
+	alphanum := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}
+
+func rand_word(str_size int) string {
+	alphanum := "abcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}
+
+func testAuthSetup(t *testing.T) Auth {
+	config, err := NewCredentials(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Auth.Testing = t
+	return config.Auth
+}

--- a/v201705/basic_operation_test.go
+++ b/v201705/basic_operation_test.go
@@ -1,0 +1,559 @@
+package v201705
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"time"
+)
+
+func ExampleCampaignService_Get() {
+	// load credentials from
+	authConf, _ := NewCredentials(context.TODO())
+	cs := NewCampaignService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all the campaigns for an account.
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	totalCount := 0
+	for {
+		campaigns, totalCount, err := cs.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"Name",
+					"Status",
+				},
+				Ordering: []OrderBy{
+					{"Name", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding campaigns")
+		}
+		for _, c := range campaigns {
+			fmt.Printf("Campaign ID %d, name '%s' and status '%s'", c.Id, c.Name, c.Status)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+	fmt.Printf("\tTotal number of campaigns found: %d.", totalCount)
+}
+
+func ExampleCampaignService_Mutate() {
+	// load credentials from
+	authConf, err := NewCredentials(context.TODO())
+	cs := NewCampaignService(&authConf.Auth)
+
+	var budgetId int64 = 1
+
+	// This example illustrates how to create campaigns.
+	campaigns, err := cs.Mutate(
+		CampaignOperations{
+			"ADD": {
+				Campaign{
+					Name:   fmt.Sprintf("Interplanetary Cruise #%d", time.Now().Unix()),
+					Status: "ACTIVE",
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+					// Budget (required) - note only the budget ID is required
+					BudgetId:               budgetId,
+					AdvertisingChannelType: "SEARCH",
+					// Optional Fields:
+					StartDate:                   time.Now().Format("20060102"),
+					AdServingOptimizationStatus: "ROTATE",
+					NetworkSetting: &NetworkSetting{
+						TargetGoogleSearch:         true,
+						TargetSearchNetwork:        true,
+						TargetContentNetwork:       false,
+						TargetPartnerSearchNetwork: false,
+					},
+					Settings: []CampaignSetting{
+						NewGeoTargetTypeSetting(
+							"DONT_CARE",
+							"DONT_CARE",
+						),
+					},
+					FrequencyCap: &FrequencyCap{
+						Impressions: 5,
+						TimeUnit:    "DAY",
+						Level:       "ADGROUP",
+					},
+				},
+				Campaign{
+					Name:   fmt.Sprintf("Interplanetary Cruise banner #%d", time.Now().Unix()),
+					Status: "PAUSED",
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+					// Budget (required) - note only the budget ID is required
+					BudgetId:               budgetId,
+					AdvertisingChannelType: "DISPLAY",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error occured creating campaign.")
+	}
+	for _, c := range campaigns {
+		fmt.Printf("Campaign with name '%s' and ID %d was added.", c.Name, c.Id)
+	}
+
+	// This example illustrates how to update a campaign, setting its status to 'PAUSED'
+	campaigns, err = cs.Mutate(
+		CampaignOperations{
+			"SET": {
+				Campaign{
+					Id:     campaigns[0].Id,
+					Status: "PAUSED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No campaigns were updated.")
+	} else {
+		fmt.Printf("Campaign ID %d was successfully updated, status was set to '%s'.", campaigns[0].Id, campaigns[0].Status)
+	}
+
+	// This example removes a campaign by setting the status to 'REMOVED'.
+	campaigns, err = cs.Mutate(
+		CampaignOperations{
+			"SET": {
+				Campaign{
+					Id:     campaigns[0].Id,
+					Status: "REMOVED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No campaigns were updated.")
+	} else {
+		fmt.Printf("Campaign ID %d was removed.", campaigns[0].Id)
+	}
+}
+
+func ExampleAdGroupService_Get() {
+	authConf, _ := NewCredentials(context.TODO())
+	ags := NewAdGroupService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all the ad groups for a campaign.
+	campaignId := "3"
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	totalCount := 0
+	for {
+		adGroups, totalCount, err := ags.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"Name",
+				},
+				Ordering: []OrderBy{
+					{"Name", "ASCENDING"},
+				},
+				Predicates: []Predicate{
+					{"CampaignId", "IN", []string{campaignId}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding ad group")
+		}
+		for _, ag := range adGroups {
+			fmt.Printf("Ad group name is '%s' and ID is %d", ag.Id, ag.Name)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+	fmt.Printf("\tCampaign ID %d has %d ad group(s).", campaignId, totalCount)
+}
+
+func ExampleAdGroupService_Mutate() {
+	authConf, err := NewCredentials(context.TODO())
+	ags := NewAdGroupService(&authConf.Auth)
+
+	var campaignId int64 = 1
+
+	// This example illustrates how to create ad groups.
+	adGroups, err := ags.Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       fmt.Sprintf("Earth to Mars Cruises #%d", time.Now().Unix()),
+					Status:     "ENABLED",
+					CampaignId: campaignId,
+					BiddingStrategyConfiguration: []BiddingStrategyConfiguration{
+						{
+							Bids: []Bid{
+								Bid{
+									Type:   "CpcBid",
+									Amount: 10000000,
+								},
+							},
+						},
+					},
+					Settings: []AdSetting{
+						AdSetting{
+							Details: []TargetSettingDetail{
+								TargetSettingDetail{
+									CriterionTypeGroup: "PLACEMENT",
+									TargetAll:          true,
+								},
+								TargetSettingDetail{
+									CriterionTypeGroup: "VERTICAL",
+									TargetAll:          false,
+								},
+							},
+						},
+					},
+				},
+				AdGroup{
+					Name:       fmt.Sprintf("Earth to Pluto Cruises #%d", time.Now().Unix()),
+					Status:     "ENABLED",
+					CampaignId: campaignId,
+					BiddingStrategyConfiguration: []BiddingStrategyConfiguration{
+						{
+							Bids: []Bid{
+								Bid{
+									Type:   "CpcBid",
+									Amount: 10000000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("")
+	} else {
+		for _, ag := range adGroups {
+			fmt.Printf("Ad group ID %d was successfully added.", ag.Id)
+		}
+	}
+
+	// This example illustrates how to update an ad group
+	adGroups, err = ags.Mutate(
+		AdGroupOperations{
+			"SET": {
+				AdGroup{
+					Id:     adGroups[0].Id,
+					Status: "PAUSE",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ad groups were updated.")
+	} else {
+		fmt.Printf("Ad group id %d was successfully updated.", adGroups[0].Id)
+	}
+
+	// This example removes an ad group by setting the status to 'REMOVED'.
+	adGroups, err = ags.Mutate(
+		AdGroupOperations{
+			"SET": {
+				AdGroup{
+					Id:     adGroups[0].Id,
+					Status: "REMOVE",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ad groups were updated.")
+	} else {
+		fmt.Printf("Ad group id %d was successfully removed.", adGroups[0].Id)
+	}
+}
+
+func ExampleAdGroupCriterionService_Get() {
+	authConf, _ := NewCredentials(context.TODO())
+	agcs := NewAdGroupCriterionService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all keywords for an ad group.
+	adGroupId := "1"
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	for {
+		adGroupCriterions, totalCount, err := agcs.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"CriteriaType",
+					"KeywordText",
+				},
+				Ordering: []OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Predicates: []Predicate{
+					{"AdGroupId", "EQUALS", []string{adGroupId}},
+					{"CriteriaType", "EQUALS", []string{"KEYWORD"}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding ad group criterion")
+		}
+		for _, agc := range adGroupCriterions {
+			kc := agc.(BiddableAdGroupCriterion).Criterion.(KeywordCriterion)
+			fmt.Printf("Keyword ID %d, type '%s' and text '%s'", kc.Id, kc.MatchType, kc.Text)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			fmt.Printf("\tAd group ID %d has %d keyword(s).", totalCount)
+			break
+		}
+	}
+}
+
+func ExampleAdGroupCriterionService_Mutate() {
+	authConf, err := NewCredentials(context.TODO())
+	agcs := NewAdGroupCriterionService(&authConf.Auth)
+
+	var adGroupId int64 = 1
+
+	// This example illustrates how to add multiple keywords to a given ad group.
+	adGroupCriterions, err := agcs.Mutate(
+		AdGroupCriterionOperations{
+			"ADD": {
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroupId,
+					Criterion: KeywordCriterion{
+						Text:      "mars cruise",
+						MatchType: "BROAD",
+					},
+					UserStatus:     "PAUSED",
+					DestinationUrl: "http://example.com/mars",
+				},
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroupId,
+					Criterion: KeywordCriterion{
+						Text:      "space hotel",
+						MatchType: "BROAD",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No keywords were added.")
+	} else {
+		fmt.Printf("Added %d keywords to ad group ID %d:", len(adGroupCriterions), adGroupId)
+		for _, agc := range adGroupCriterions {
+			k := agc.(BiddableAdGroupCriterion).Criterion.(KeywordCriterion)
+			fmt.Printf("\tKeyword ID is %d and type is '%s'", k.Id, k.MatchType)
+		}
+	}
+
+	// This example updates the bid of a keyword.
+	keywordCriterion := adGroupCriterions[0].(BiddableAdGroupCriterion).Criterion.(KeywordCriterion)
+	biddingStrategyConfigurations := BiddingStrategyConfiguration{
+		Bids: []Bid{
+			Bid{
+				Type:   "CpcBid",
+				Amount: 10000000,
+			},
+		},
+	}
+	adGroupCriterions, err = agcs.Mutate(
+		AdGroupCriterionOperations{
+			"SET": {
+				BiddableAdGroupCriterion{
+					AdGroupId:                    adGroupId,
+					Criterion:                    keywordCriterion,
+					BiddingStrategyConfiguration: &biddingStrategyConfigurations,
+				},
+			},
+		},
+	)
+	biddableAdGroupCriterion := adGroupCriterions[0].(BiddableAdGroupCriterion)
+	keywordCriterion = biddableAdGroupCriterion.Criterion.(KeywordCriterion)
+	if err != nil {
+		fmt.Printf("No keywords were updated.")
+	} else {
+		fmt.Printf("Keyword ID %d was successfully updated, current bids are:", keywordCriterion.Id)
+		for _, bid := range biddableAdGroupCriterion.BiddingStrategyConfiguration.Bids {
+			fmt.Printf("\tType: '%s', value: %d", bid.Type, bid.Amount)
+		}
+	}
+
+	// This example removes a keyword using the 'REMOVE' operator.
+	adGroupCriterions, err = agcs.Mutate(
+		AdGroupCriterionOperations{
+			"REMOVE": {
+				BiddableAdGroupCriterion{
+					AdGroupId: adGroupId,
+					Criterion: keywordCriterion,
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No keywords were removed.")
+	} else {
+		biddableAdGroupCriterion := adGroupCriterions[0].(BiddableAdGroupCriterion)
+		keywordCriterion = biddableAdGroupCriterion.Criterion.(KeywordCriterion)
+		fmt.Printf("Keyword ID %d was successfully removed.", keywordCriterion.Id)
+	}
+}
+
+func ExampleAdGroupAdService_Get() {
+	authConf, _ := NewCredentials(context.TODO())
+	agas := NewAdGroupAdService(&authConf.Auth)
+
+	// This example illustrates how to retrieve all text ads for an ad group.
+	adGroupId := "1"
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	var totalCount int64 = 0
+	for {
+		adGroupAds, totalCount, err := agas.Get(
+			Selector{
+				Fields: []string{
+					"Id",
+					"Status",
+					"AdType",
+				},
+				Ordering: []OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Predicates: []Predicate{
+					{"AdGroupId", "IN", []string{adGroupId}},
+					{"Status", "IN", []string{"ENABLED", "PAUSED", "DISABLED"}},
+					{"AdType", "EQUALS", []string{"TEXT_AD"}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding ad group ad")
+		}
+		for _, aga := range adGroupAds {
+			ta := aga.(TextAd)
+			fmt.Printf("Ad ID is %d, type is 'TextAd' and status is '%s'", ta.Id, ta.Status)
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+	fmt.Printf("\tAd group ID %d has %d ad(s).", totalCount)
+}
+
+func ExampleAdGroupAdService_Mutate() {
+	authConf, err := NewCredentials(context.TODO())
+	agas := NewAdGroupAdService(&authConf.Auth)
+
+	// This example illustrates how to add text ads to a given ad group.
+	var adGroupId int64 = 1
+
+	adGroupAds, err := agas.Mutate(
+		AdGroupAdOperations{
+			"ADD": {
+				NewTextAd(
+					adGroupId,
+					"http://www.example.com",
+					"example.com",
+					"Luxury Cruise to Mars",
+					"Visit the Red Planet in style.",
+					"Low-gravity fun for everyone!",
+					"ACTIVE",
+				),
+				NewTextAd(
+					adGroupId,
+					"http://www.example.com",
+					"www.example.com",
+					"Luxury Cruise to Mars",
+					"Enjoy your stay at Red Planet.",
+					"Buy your tickets now!",
+					"ACTIVE",
+				),
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ads were added.")
+	} else {
+		fmt.Printf("Added %d ad(s) to ad group ID %d:", len(adGroupAds), adGroupId)
+		for _, ada := range adGroupAds {
+			ta := ada.(TextAd)
+			fmt.Printf("\tAd ID %d, type 'TextAd' and status '%s'", ta.Id, ta.Status)
+		}
+	}
+
+	// This example illustrates how to update an ad, setting its status to 'PAUSED'.
+	textAdId := adGroupAds[0].(TextAd).Id
+	adGroupAds, err = agas.Mutate(
+		AdGroupAdOperations{
+			"SET": {
+				TextAd{
+					AdGroupId: adGroupId,
+					Id:        textAdId,
+					Status:    "PAUSED",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ads were updated.")
+	} else {
+		textAd := adGroupAds[0].(TextAd)
+		fmt.Printf("Ad ID %d was successfully updated, status set to '%s'.", textAd.Id, textAd.Status)
+	}
+
+	// This example removes an ad using the 'REMOVE' operator.
+	adGroupAds, err = agas.Mutate(
+		AdGroupAdOperations{
+			"SET": {
+				TextAd{
+					AdGroupId: adGroupId,
+					Id:        textAdId,
+					Status:    "REMOVE",
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("No ads were removed.")
+	} else {
+		textAd := adGroupAds[0].(TextAd)
+		fmt.Printf("Ad ID %d was successfully removed.", textAd.Id)
+	}
+}

--- a/v201705/batch_job.go
+++ b/v201705/batch_job.go
@@ -1,0 +1,316 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type BatchJobService struct {
+	Auth
+}
+
+type BatchJobPage struct {
+	TotalNumEntries int        `xml:"rval>totalNumEntries"`
+	BatchJobs       []BatchJob `xml:"rval>entries"`
+}
+
+type BatchJobOperations struct {
+	BatchJobOperations []BatchJobOperation
+}
+
+type Operation struct {
+	Operator string      `xml:"https://adwords.google.com/api/adwords/cm/v201705 operator"`
+	Operand  interface{} `xml:"operand"`
+	Xsi_type string      `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+}
+
+type BatchJobOperation struct {
+	Operator string   `xml:"operator"`
+	Operand  BatchJob `xml:"operand"`
+}
+
+type BatchJob struct {
+	Id               int64                    `xml:"id,omitempty" json:",string"`
+	Status           string                   `xml:"status,omitempty"`
+	ProgressStats    *ProgressStats           `xml:"progressStats,omitempty"`
+	UploadUrl        *TemporaryUrl            `xml:"uploadUrl,omitempty"`
+	DownloadUrl      *TemporaryUrl            `xml:"downloadUrl,omitempty"`
+	ProcessingErrors *BatchJobProcessingError `xml:"processingErrors,omitempty"`
+}
+
+type TemporaryUrl struct {
+	Url        string `xml:"url"`
+	Expiration string `xml:"expiration,"`
+}
+
+type BatchJobProcessingError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type ProgressStats struct {
+	NumOperationsExecuted    int64 `xml:"numOperationsExecuted" json:",string"`
+	NumOperationsSucceeded   int64 `xml:"numOperationsSucceeded" json:",string"`
+	EstimatedPercentExecuted int   `xml:"estimatedPercentExecuted"`
+	NumResultsWritten        int64 `xml:"numResultsWritten" json:",string"`
+}
+
+type MutateResults struct {
+	Result    MutateResult   `xml:"result"`
+	ErrorList []MutateErrors `xml:"errorList"`
+	Index     int            `xml:"index"`
+}
+
+type MutateErrors struct {
+	Errors EntityError `xml:"errors"`
+}
+
+type MutateResult interface{}
+
+func NewBatchJobService(auth *Auth) *BatchJobService {
+	return &BatchJobService{Auth: *auth}
+}
+
+// Get queries the status of existing BatchJobs
+//
+//	Example
+//
+//	batchJobs, err := batchJobService.Get(
+// 		gads.Selector{
+//			Fields: []string{
+//				"Id",
+//				"Status",
+//				"DownloadUrl",
+//				"ProcessingErrors",
+//				"ProgressStats",
+//			},
+//			Predicates: []gads.Predicate{
+//				{"Id", "EQUALS", []string{strconv.FormatInt(jobId, 10)}},
+//			},
+//		},
+//	)
+//
+// 	https://developers.google.com/adwords/api/docs/reference/v201705/BatchJobService#get
+func (s *BatchJobService) Get(selector Selector) (batchJobPage BatchJobPage, err error) {
+
+	selector.XMLName = xml.Name{baseUrl, "selector"}
+	respBody, err := s.Auth.request(
+		batchJobServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return batchJobPage, err
+	}
+
+	err = xml.Unmarshal([]byte(respBody), &batchJobPage)
+
+	return batchJobPage, err
+}
+
+// Mutate allows you to create or update a BatchJob
+//
+//	Example
+//
+//	resp, err := batchJobService.Mutate(
+// 		gads.BatchJobOperations{
+//			BatchJobOperations: []gads.BatchJobOperation{
+//				gads.BatchJobOperation{
+//					Operator: "ADD",
+//					Operand: gads.BatchJob{},
+//				},
+//			},
+//		},
+//	)
+//
+// 	https://developers.google.com/adwords/api/docs/reference/v201705/BatchJobService#mutate
+func (s *BatchJobService) Mutate(batchJobOperations BatchJobOperations) (batchJobs []BatchJob, err error) {
+
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []BatchJobOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: batchJobOperations.BatchJobOperations}
+	respBody, err := s.Auth.request(batchJobServiceUrl, "mutate", mutation)
+	if err != nil {
+		return batchJobs, err
+	}
+	mutateResp := struct {
+		BatchJobs []BatchJob `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return batchJobs, err
+	}
+
+	return mutateResp.BatchJobs, err
+}
+
+func (s *BatchJobService) Query() {
+
+}
+
+func (mr *MutateResults) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "index":
+				if err := dec.DecodeElement(&mr.Index, &start); err != nil {
+					return err
+				}
+			case "errorList":
+				if err := dec.DecodeElement(&mr.ErrorList, &start); err != nil {
+					return err
+				}
+			case "AdGroup":
+				ag := AdGroup{}
+				err := dec.DecodeElement(&ag, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = ag
+			case "AdGroupAd":
+				aga := AdGroupAds{}
+				err := dec.DecodeElement(&aga, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = aga
+			case "AdGroupAdLabel":
+				agal := AdGroupAdLabel{}
+				err := dec.DecodeElement(&agal, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agal
+			case "AdGroupCriterion":
+				agc := AdGroupCriterions{}
+				err := dec.DecodeElement(&agc, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agc
+			case "AdGroupCriterionLabel":
+				agcl := AdGroupCriterionLabel{}
+				err := dec.DecodeElement(&agcl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agcl
+			case "AdGroupExtensionSetting":
+				cl := AdGroupExtensionSetting{}
+				err := dec.DecodeElement(&cl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cl
+			case "AdGroupLabel":
+				agl := AdGroupLabel{}
+				err := dec.DecodeElement(&agl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = agl
+			case "Budget":
+				b := Budget{}
+				err := dec.DecodeElement(&b, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = b
+			case "Campaign":
+				c := Campaign{}
+				err := dec.DecodeElement(&c, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = c
+			case "CampaignCriterion":
+				cc := CampaignCriterions{}
+				err := dec.DecodeElement(&cc, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cc
+			case "CampaignExtensionSetting":
+				cl := CampaignExtensionSetting{}
+				err := dec.DecodeElement(&cl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cl
+			case "CampaignLabel":
+				cl := CampaignLabel{}
+				err := dec.DecodeElement(&cl, &start)
+				if err != nil {
+					return err
+				}
+				mr.Result = cl
+			case "result":
+				break
+			default:
+				return fmt.Errorf("unknown MutateResults field %s", tag)
+			}
+		}
+	}
+	return err
+}
+
+// getXsiType validates the schema instance type and returns it since Bulk Mutate requires it to be set
+func getXsiType(objectName string) (string, bool) {
+	switch {
+	case strings.Contains(objectName, "AdGroupExtensionSettingOperation"):
+		return "AdGroupExtensionSettingOperation", true
+	case strings.Contains(objectName, "AdGroupAdLabelOperation"):
+		return "AdGroupAdLabelOperation", true
+	case strings.Contains(objectName, "AdGroupAdOperation"):
+		return "AdGroupAdOperation", true
+	case strings.Contains(objectName, "AdGroupBidModifierOperation"):
+		return "AdGroupBidModifierOperation", true
+	case strings.Contains(objectName, "AdGroupCriterionLabelOperation"):
+		return "AdGroupCriterionLabelOperation", true
+	case strings.Contains(objectName, "AdGroupCriterionOperation"):
+		return "AdGroupCriterionOperation", true
+	case strings.Contains(objectName, "AdGroupLabelOperation"):
+		return "AdGroupLabelOperation", true
+	case strings.Contains(objectName, "AdGroupOperation"):
+		return "AdGroupOperation", true
+	case strings.Contains(objectName, "BudgetOperation"):
+		return "BudgetOperation", true
+	case strings.Contains(objectName, "CampaignAdExtensionOperation"):
+		return "CampaignAdExtensionOperation", true
+	case strings.Contains(objectName, "CampaignExtensionSettingOperation"):
+		return "CampaignExtensionSettingOperation", true
+	case strings.Contains(objectName, "CampaignCriterionOperation"):
+		return "CampaignCriterionOperation", true
+	case strings.Contains(objectName, "CampaignLabelOperation"):
+		return "CampaignLabelOperation", true
+	case strings.Contains(objectName, "CampaignOperation"):
+		return "CampaignOperation", true
+	case strings.Contains(objectName, "FeedItemOperation"):
+		return "FeedItemOperation", true
+	default:
+		return "", false
+	}
+}

--- a/v201705/batch_job_helper.go
+++ b/v201705/batch_job_helper.go
@@ -1,0 +1,193 @@
+package v201705
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+)
+
+type BatchJobHelper struct {
+	Auth
+}
+
+func NewBatchJobHelper(auth *Auth) *BatchJobHelper {
+	return &BatchJobHelper{Auth: *auth}
+}
+
+//	UploadBatchJobOperations uploads batch operations to an BatchJob.UploadUrl from BatchJobService.Mutate
+//
+//	Example
+//
+//	ago := gads.AdGroupOperations{
+//			"ADD": {
+//				gads.AdGroup{
+// 					Name:       "test ad group " + rand_str(10),
+// 					Status:     "PAUSED",
+// 					CampaignId: campaignId,
+// 				},
+// 				gads.AdGroup{
+// 					Name:       "test ad group " + rand_str(10),
+// 					Status:     "PAUSED",
+// 					CampaignId: campaignId,
+// 				},
+// 			},
+// 		}
+//
+//	var operations []interface{}
+//	operations = append(operations, ago)
+//	err = batchJobHelper.UploadBatchJobOperations(operations, UploadUrl)
+//
+//
+//	https://developers.google.com/adwords/api/docs/guides/batch-jobs?hl=en#upload_operations_to_the_upload_url
+func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, url TemporaryUrl) (err error) {
+
+	var operations []Operation
+	for _, operation := range jobOperations {
+		if operationType, valid := getXsiType(reflect.ValueOf(operation).Type().String()); valid {
+			switch reflect.TypeOf(operation).Kind() {
+			case reflect.Map:
+				ops := reflect.ValueOf(operation)
+
+				keys := ops.MapKeys()
+
+				for _, action := range keys {
+					jobs := ops.MapIndex(action)
+
+					for i := 0; i < jobs.Len(); i++ {
+
+						operations = append(operations,
+							Operation{
+								Operator: action.String(),
+								Operand:  jobs.Index(i).Interface(),
+								Xsi_type: operationType,
+							},
+						)
+					}
+				}
+			}
+		}
+	}
+
+	if len(operations) > 0 {
+		mutation := struct {
+			XMLName xml.Name
+			Ops     []Operation `xml:"operations"`
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "mutate",
+			},
+			Ops: operations,
+		}
+
+		client := &http.Client{}
+
+		// Need to get the upload url
+		req, err := http.NewRequest("POST", url.Url, nil)
+		if err != nil {
+			return err
+		}
+
+		req.Header.Set("Content-Type", "application/xml")
+		req.Header.Set("Content-Length", "0")
+		req.Header.Set("x-goog-resumable", "start")
+
+		response, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer response.Body.Close()
+
+		// If we got a valid upload url it will be 201
+		if response.StatusCode != http.StatusCreated {
+			respBody, err := ioutil.ReadAll(response.Body)
+
+			if err != nil {
+				return err
+			}
+			return errors.New(fmt.Sprintf("Invalid response received. %v received. Body: %v", response.StatusCode, string(respBody)))
+		}
+
+		location := response.Header.Get("Location")
+
+		reqBody, err := xml.MarshalIndent(mutation, "  ", "  ")
+		bodyLength := len(reqBody)
+
+		if err != nil {
+			return err
+		}
+
+		req, err = http.NewRequest("PUT", location, bytes.NewReader(reqBody))
+
+		if err != nil {
+			return err
+		}
+
+		// Set headers for incremental upload
+		req.Header.Set("Content-Type", "application/xml")
+		req.Header.Set("Content-Length", string(bodyLength))
+		req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%v/%v", bodyLength-1, bodyLength))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		respBody, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return err
+		}
+
+		// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+		if level := os.Getenv("DEBUG"); level != "" {
+			fmt.Printf("response ->\n%s\n", string(respBody))
+		}
+
+		// resp seems to only return 200's and there is no error handling, but if we happen to get invalid status lets try to do something with it
+		if resp.StatusCode != http.StatusOK {
+			return errors.New("Non-200 response returned Body: " + string(respBody))
+		}
+	}
+
+	return err
+}
+
+//	DownloadBatchJob download batch operations from an BatchJob.DownloadUrl from BatchJobService.Get
+//
+//	Example
+//
+//	mutateResult, err := batchJobHelper.DownloadBatchJob(*batchJobs.BatchJobs[0].DownloadUrl)
+//
+//	https://developers.google.com/adwords/api/docs/guides/batch-jobs?hl=en#download_the_batch_job_results_and_check_for_errors
+func (s *BatchJobHelper) DownloadBatchJob(url TemporaryUrl) (mutateResults []MutateResults, err error) {
+	resp, err := http.Get(url.Url)
+
+	if err != nil {
+		return mutateResults, err
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+
+	// Added some logging/"poor man's" debugging to inspect outbound SOAP requests
+	if level := os.Getenv("DEBUG"); level != "" {
+		fmt.Printf("response ->\n%s\n", string(respBody))
+	}
+
+	soapResp := struct {
+		MutateResults []MutateResults `xml:"rval"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &soapResp)
+	if err != nil {
+		return mutateResults, err
+	}
+
+	return soapResp.MutateResults, err
+}

--- a/v201705/biddable_ad_group_criterion.go
+++ b/v201705/biddable_ad_group_criterion.go
@@ -1,0 +1,158 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type BiddableAdGroupCriterion struct {
+	AdGroupId    int64     `xml:"adGroupId"`
+	CriterionUse string    `xml:"criterionUse"`
+	Criterion    Criterion `xml:"criterion"`
+
+	// BiddableAdGroupCriterion
+	UserStatus          string   `xml:"userStatus,omitempty"`
+	SystemServingStatus string   `xml:"systemServingStatus,omitempty"`
+	ApprovalStatus      string   `xml:"approvalStatus,omitempty"`
+	DisapprovalReasons  []string `xml:"disapprovalReasons,omitempty"`
+	DestinationUrl      string   `xml:"destinationUrl,omitempty"`
+
+	// TODO add ExperimentData
+	FirstPageCpc *Cpc `xml:"firstPageCpc,omitempty"`
+	TopOfPageCpc *Cpc `xml:"topOfPageCpc,omitempty"`
+
+	QualityInfo *QualityInfo `xml:"qualityInfo,omitempty"`
+
+	BiddingStrategyConfiguration *BiddingStrategyConfiguration `xml:"biddingStrategyConfiguration,omitempty"`
+	BidModifier                  int64                         `xml:"bidModifier,omitempty"`
+
+	FinalUrls           []string         `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string         `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []string         `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string           `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters CustomParameters `xml:"urlCustomParameters,omitempty"`
+	Labels              []Label          `xml:"labels,omitempty"`
+}
+
+func (bagc BiddableAdGroupCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"BiddableAdGroupCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&bagc.AdGroupId, xml.StartElement{Name: xml.Name{baseUrl, "adGroupId"}})
+	criterionMarshalXML(bagc.Criterion, e)
+	if bagc.UserStatus != "" {
+		e.EncodeElement(&bagc.UserStatus, xml.StartElement{Name: xml.Name{baseUrl, "userStatus"}})
+	}
+	if bagc.DestinationUrl != "" {
+		e.EncodeElement(&bagc.DestinationUrl, xml.StartElement{Name: xml.Name{baseUrl, "destinationUrl"}})
+	}
+	e.EncodeElement(&bagc.BiddingStrategyConfiguration, xml.StartElement{Name: xml.Name{baseUrl, "biddingStrategyConfiguration"}})
+	if bagc.BidModifier != 0 {
+		e.EncodeElement(&bagc.BidModifier, xml.StartElement{Name: xml.Name{baseUrl, "bidModifier"}})
+	}
+	e.EncodeElement(&bagc.UrlCustomParameters, xml.StartElement{Name: xml.Name{baseUrl, "urlCustomParameters"}})
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (bagc *BiddableAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "adGroupId":
+				if err := dec.DecodeElement(&bagc.AdGroupId, &start); err != nil {
+					return err
+				}
+			case "criterionUse":
+				if err := dec.DecodeElement(&bagc.CriterionUse, &start); err != nil {
+					return err
+				}
+			case "criterion":
+				criterion, err := criterionUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				bagc.Criterion = criterion
+			case "userStatus":
+				if err := dec.DecodeElement(&bagc.UserStatus, &start); err != nil {
+					return err
+				}
+			case "systemServingStatus":
+				if err := dec.DecodeElement(&bagc.SystemServingStatus, &start); err != nil {
+					return err
+				}
+			case "approvalStatus":
+				if err := dec.DecodeElement(&bagc.ApprovalStatus, &start); err != nil {
+					return err
+				}
+			case "disapprovalReasons":
+				if err := dec.DecodeElement(&bagc.DisapprovalReasons, &start); err != nil {
+					return err
+				}
+			case "destinationUrl":
+				if err := dec.DecodeElement(&bagc.DestinationUrl, &start); err != nil {
+					return err
+				}
+			case "firstPageCpc":
+				if err := dec.DecodeElement(&bagc.FirstPageCpc, &start); err != nil {
+					return err
+				}
+			case "topOfPageCpc":
+				if err := dec.DecodeElement(&bagc.TopOfPageCpc, &start); err != nil {
+					return err
+				}
+			case "qualityInfo":
+				if err := dec.DecodeElement(&bagc.QualityInfo, &start); err != nil {
+					return err
+				}
+			case "biddingStrategyConfiguration":
+				if err := dec.DecodeElement(&bagc.BiddingStrategyConfiguration, &start); err != nil {
+					return err
+				}
+			case "bidModifier":
+				if err := dec.DecodeElement(&bagc.BidModifier, &start); err != nil {
+					return err
+				}
+			case "finalUrls":
+				if err := dec.DecodeElement(&bagc.FinalUrls, &start); err != nil {
+					return err
+				}
+			case "finalMobileUrls":
+				if err := dec.DecodeElement(&bagc.FinalMobileUrls, &start); err != nil {
+					return err
+				}
+			case "finalAppUrls":
+				if err := dec.DecodeElement(&bagc.FinalAppUrls, &start); err != nil {
+					return err
+				}
+			case "trackingUrlTemplate":
+				if err := dec.DecodeElement(&bagc.TrackingUrlTemplate, &start); err != nil {
+					return err
+				}
+			case "urlCustomParameters":
+				if err := dec.DecodeElement(&bagc.UrlCustomParameters, &start); err != nil {
+					return err
+				}
+			case "labels":
+				if err := dec.DecodeElement(&bagc.Labels, &start); err != nil {
+					return err
+				}
+			case "AdGroupCriterion.Type":
+				break
+			default:
+				return fmt.Errorf("unknown BiddableAdGroupCriterion field %s", tag)
+			}
+		}
+	}
+	return nil
+}

--- a/v201705/bidding_strategy.go
+++ b/v201705/bidding_strategy.go
@@ -1,0 +1,24 @@
+package v201705
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type BiddingStrategyService struct {
+	Auth
+}
+
+func NewBiddingStrategyService(auth *Auth) *BiddingStrategyService {
+	return &BiddingStrategyService{Auth: *auth}
+}
+
+/*
+type AdGroupBidModifier struct {
+  CampaignId        int64     `xml:"campaignId"`
+  AdGroupId         int64     `xml:"adGroupId"`
+  Criterion         Criterion `xml:"criterion"`
+  BidModifier       float64   `xml:"bidModifier"`
+  BidModifierSource string    `xml:"bidModifierSource"`
+}
+*/

--- a/v201705/budget.go
+++ b/v201705/budget.go
@@ -1,0 +1,113 @@
+package v201705
+
+import (
+	"encoding/xml"
+	//  "fmt"
+)
+
+// A budgetService holds the connection information for the
+// budget service.
+type BudgetService struct {
+	Auth
+}
+
+// NewBudgetService creates a new budgetService
+func NewBudgetService(auth *Auth) *BudgetService {
+	return &BudgetService{Auth: *auth}
+}
+
+// A Budget represents an allotment of money to be spent over a fixed
+// period of time.
+type Budget struct {
+	Id         int64  `xml:"budgetId,omitempty"`           // A unique identifier
+	Name       string `xml:"name"`                         // A descriptive name
+	Period     string `xml:"period"`                       // The period to spend the budget
+	Amount     int64  `xml:"amount>microAmount"`           // The amount in cents
+	Delivery   string `xml:"deliveryMethod"`               // The rate at which the budget spent. valid options are STANDARD or ACCELERATED.
+	References int64  `xml:"referenceCount,omitempty"`     // The number of campaigns using the budget
+	Shared     bool   `xml:"isExplicitlyShared,omitempty"` // If this budget was created to be shared across campaigns
+	Status     string `xml:"status,omitempty"`             // The status of the budget. can be ENABLED, REMOVED, UNKNOWN
+}
+
+// A BudgetOperations maps operations to the budgets they will be performed
+// on.  Budgets operations can be 'ADD', 'REMOVE' or 'SET'
+type BudgetOperations map[string][]Budget
+
+func budgetError() (err error) {
+	return err
+}
+
+// Get returns budgets matching a given selector and the total count of matching budgets.
+func (s *BudgetService) Get(selector Selector) (budgets []Budget, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "selector"}
+	respBody, err := s.Auth.request(
+		budgetServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return budgets, totalCount, err
+	}
+	getResp := struct {
+		Size    int64    `xml:"rval>totalNumEntries"`
+		Budgets []Budget `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return budgets, totalCount, err
+	}
+	return getResp.Budgets, getResp.Size, err
+}
+
+// Mutate takes a budgetOperations and creates, modifies or destroys the associated budgets.
+func (s *BudgetService) Mutate(budgetOperations BudgetOperations) (budgets []Budget, err error) {
+	type budgetOperation struct {
+		Action string `xml:"operator"`
+		Budget Budget `xml:"operand"`
+	}
+	operations := []budgetOperation{}
+	for action, budgets := range budgetOperations {
+		for _, budget := range budgets {
+			operations = append(operations,
+				budgetOperation{
+					Action: action,
+					Budget: budget,
+				},
+			)
+		}
+	}
+	respBody, err := s.Auth.request(
+		budgetServiceUrl,
+		"mutate",
+		struct {
+			XMLName xml.Name
+			Ops     []budgetOperation `xml:"operations"`
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "mutate",
+			},
+			Ops: operations,
+		},
+	)
+	if err != nil {
+		return budgets, err
+	}
+	mutateResp := struct {
+		Budgets []Budget `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return budgets, err
+	}
+	return mutateResp.Budgets, err
+}

--- a/v201705/budget_order.go
+++ b/v201705/budget_order.go
@@ -1,0 +1,14 @@
+package v201705
+
+import (
+//	"encoding/xml"
+//	"fmt"
+)
+
+type BudgetOrderService struct {
+	Auth
+}
+
+func NewBudgetOrderService(auth *Auth) *BudgetOrderService {
+	return &BudgetOrderService{Auth: *auth}
+}

--- a/v201705/budget_test.go
+++ b/v201705/budget_test.go
@@ -1,0 +1,111 @@
+package v201705
+
+import (
+	"testing"
+)
+
+func testBudgetService(t *testing.T) (service *BudgetService) {
+	return &BudgetService{Auth: testAuthSetup(t)}
+}
+
+func testBudget(t *testing.T) (Budget, func()) {
+	s := testBudgetService(t)
+	budgets, err := s.Mutate(
+		BudgetOperations{
+			"ADD": {
+				Budget{
+					Name:     "testbudget " + rand_str(10),
+					Period:   "DAILY",
+					Amount:   50000000,
+					Delivery: "STANDARD",
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupBudget := func() {
+		_, err = s.Mutate(BudgetOperations{"REMOVE": budgets})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	return budgets[0], cleanupBudget
+}
+
+func TestBudget(t *testing.T) {
+	s := testBudgetService(t)
+	budgets, err := s.Mutate(
+		BudgetOperations{
+			"ADD": {
+				Budget{
+					Name:     "testbudget " + rand_str(10),
+					Period:   "DAILY",
+					Amount:   50000000,
+					Delivery: "STANDARD",
+				},
+				Budget{
+					Name:     "test budget " + rand_str(10),
+					Period:   "DAILY",
+					Amount:   50000000,
+					Delivery: "STANDARD",
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func(bs []Budget) {
+		_, err = s.Mutate(BudgetOperations{"REMOVE": bs})
+		if err != nil {
+			t.Error(err)
+		}
+	}(budgets)
+
+	foundBudgets, _, err := s.Get(
+		Selector{
+			Fields: []string{
+				"BudgetId",
+				"BudgetName",
+				"Period",
+				"Amount",
+				"DeliveryMethod",
+				"BudgetReferenceCount",
+				"IsBudgetExplicitlyShared",
+				"BudgetStatus",
+			},
+			Predicates: []Predicate{
+				{"Amount", "LESS_THAN_EQUALS", []string{"500000000"}},
+				{"BudgetStatus", "EQUALS", []string{"ENABLED"}},
+			},
+			Ordering: []OrderBy{
+				{"BudgetId", "ASCENDING"},
+				{"Amount", "ASCENDING"},
+			},
+			Paging: &Paging{
+				Offset: 0,
+				Limit:  100,
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("found %d budgets\n", len(foundBudgets))
+	for _, b := range budgets {
+		func(budget Budget) {
+			for _, foundBudget := range foundBudgets {
+				if foundBudget.Id == budget.Id {
+					return
+				}
+			}
+			t.Errorf("budget %d not found in \n%#v\n", budget.Id, foundBudgets)
+		}(b)
+	}
+}

--- a/v201705/campaign.go
+++ b/v201705/campaign.go
@@ -1,0 +1,391 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+// A campaignService holds the connection information for the
+// campaign service.
+type CampaignService struct {
+	Auth
+}
+
+// NewCampaignService creates a new campaignService
+func NewCampaignService(auth *Auth) *CampaignService {
+	return &CampaignService{Auth: *auth}
+}
+
+// ConversionOptimizerEligibility
+//
+// RejectionReasons can be any of
+//   "CAMPAIGN_IS_NOT_ACTIVE", "NOT_CPC_CAMPAIGN","CONVERSION_TRACKING_NOT_ENABLED",
+//   "NOT_ENOUGH_CONVERSIONS", "UNKNOWN"
+//
+type conversionOptimizerEligibility struct {
+	Eligible         bool     `xml:"eligible"`         // is eligible for optimization
+	RejectionReasons []string `xml:"rejectionReasons"` // reason for why campaign is
+	// not eligible for conversion optimization.
+}
+
+type FrequencyCap struct {
+	Impressions int64  `xml:"impressions"`
+	TimeUnit    string `xml:"timeUnit"`
+	Level       string `xml:"level,omitempty"`
+}
+
+type CampaignSetting struct {
+	XMLName xml.Name `xml:"settings"`
+	Type    string   `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+
+	// GeoTargetTypeSetting
+	PositiveGeoTargetType *string `xml:"positiveGeoTargetType,omitempty"`
+	NegativeGeoTargetType *string `xml:"negativeGeoTargetType,omitempty"`
+
+	// RealTimeBiddingSetting
+	OptIn *bool `xml:"optIn,omitempty"`
+
+	// DynamicSearchAdsSetting
+	DomainName   *string `xml:"domainName,omitempty"`
+	LanguageCode *string `xml:"langaugeCode,omitempty"`
+
+	// TrackingSetting
+	TrackingUrl *string `xml:"trackingUrl,omitempty"`
+}
+
+func NewDynamicSearchAdsSetting(domainName, languageCode string) CampaignSetting {
+	return CampaignSetting{
+		Type:         "DynamicSearchAdsSetting",
+		DomainName:   &domainName,
+		LanguageCode: &languageCode,
+	}
+}
+
+func NewGeoTargetTypeSetting(positiveGeoTargetType, negativeGeoTargetType string) CampaignSetting {
+	return CampaignSetting{
+		Type: "GeoTargetTypeSetting",
+		PositiveGeoTargetType: &positiveGeoTargetType,
+		NegativeGeoTargetType: &negativeGeoTargetType,
+	}
+}
+
+func NewRealTimeBiddingSetting(optIn bool) CampaignSetting {
+	return CampaignSetting{
+		Type:  "RealTimeBiddingSetting",
+		OptIn: &optIn,
+	}
+}
+
+func NewTrackingSetting(trackingUrl string) CampaignSetting {
+	return CampaignSetting{
+		Type:        "TrackingSetting",
+		TrackingUrl: &trackingUrl,
+	}
+}
+
+type NetworkSetting struct {
+	TargetGoogleSearch         bool `xml:"https://adwords.google.com/api/adwords/cm/v201705 targetGoogleSearch"`
+	TargetSearchNetwork        bool `xml:"https://adwords.google.com/api/adwords/cm/v201705 targetSearchNetwork"`
+	TargetContentNetwork       bool `xml:"https://adwords.google.com/api/adwords/cm/v201705 targetContentNetwork"`
+	TargetPartnerSearchNetwork bool `xml:"https://adwords.google.com/api/adwords/cm/v201705 targetPartnerSearchNetwork"`
+}
+
+type BiddingScheme struct {
+	Type               string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	EnhancedCpcEnabled bool   `xml:"enhancedCpcEnabled"`
+}
+
+type Bid struct {
+	Type         string  `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Amount       int64   `xml:"bid>microAmount"`
+	CpcBidSource *string `xml:"cpcBidSource"`
+	CpmBidSource *string `xml:"cpmBidSource"`
+}
+
+type BiddingStrategyConfiguration struct {
+	StrategyId     int64          `xml:"biddingStrategyId,omitempty"`
+	StrategyName   string         `xml:"biddingStrategyName,omitempty"`
+	StrategyType   string         `xml:"biddingStrategyType,omitempty"`
+	StrategySource string         `xml:"biddingStrategySource,omitempty"`
+	Scheme         *BiddingScheme `xml:"biddingScheme,omitempty"`
+	Bids           []Bid          `xml:"bids"`
+}
+
+type CustomParameter struct {
+	Key      string `xml:"key"`
+	Value    string `xml:"value"`
+	IsRemove bool   `xml:"isRemove"`
+}
+
+type CustomParameters struct {
+	CustomParameters []CustomParameter `xml:"parameters"`
+	DoReplace        bool              `xml:"doReplace"`
+}
+
+type Campaign struct {
+	Id                             int64                           `xml:"id,omitempty"`
+	Name                           string                          `xml:"name"`
+	Status                         string                          `xml:"status"`                  // Status: "ENABLED", "PAUSED", "REMOVED"
+	ServingStatus                  *string                         `xml:"servingStatus,omitempty"` // ServingStatus: "SERVING", "NONE", "ENDED", "PENDING", "SUSPENDED"
+	StartDate                      string                          `xml:"startDate"`
+	EndDate                        *string                         `xml:"endDate,omitempty"`
+	BudgetId                       int64                           `xml:"budget>budgetId"`
+	ConversionOptimizerEligibility *conversionOptimizerEligibility `xml:"conversionOptimizerEligibility"`
+	AdServingOptimizationStatus    string                          `xml:"adServingOptimizationStatus"`
+	FrequencyCap                   *FrequencyCap                   `xml:"frequencyCap"`
+	Settings                       []CampaignSetting               `xml:"settings"`
+	AdvertisingChannelType         string                          `xml:"advertisingChannelType,omitempty"`    // "UNKNOWN", "SEARCH", "DISPLAY", "SHOPPING"
+	AdvertisingChannelSubType      *string                         `xml:"advertisingChannelSubType,omitempty"` // "UNKNOWN", "SEARCH_MOBILE_APP", "DISPLAY_MOBILE_APP", "SEARCH_EXPRESS", "DISPLAY_EXPRESS"
+	NetworkSetting                 *NetworkSetting                 `xml:"networkSetting"`
+	Labels                         []Label                         `xml:"labels"`
+	BiddingStrategyConfiguration   *BiddingStrategyConfiguration   `xml:"biddingStrategyConfiguration"`
+	ForwardCompatibilityMap        *map[string]string              `xml:"forwardCompatibilityMap,omitempty"`
+	TrackingUrlTemplate            *string                         `xml:"trackingUrlTemplate"`
+	UrlCustomParameters            *CustomParameters               `xml:"urlCustomParameters"`
+	Errors                         []error                         `xml:"-"`
+}
+
+type CampaignOperations map[string][]Campaign
+
+type CampaignLabel struct {
+	CampaignId int64 `xml:"campaignId"`
+	LabelId    int64 `xml:"labelId"`
+}
+
+type CampaignLabelOperations map[string][]CampaignLabel
+
+// Get returns an array of Campaign's and the total number of campaign's matching
+// the selector.
+//
+// Example
+//
+//   campaigns, totalCount, err := campaignService.Get(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//         "Status",
+//         "AdGroupCreativeApprovalStatus",
+//         "AdGroupAdDisapprovalReasons",
+//         "AdGroupAdTrademarkDisapproved",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"AdGroupId", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "Id", "Name", "Status", "ServingStatus", "StartDate", "EndDate", "AdServingOptimizationStatus",
+//   "Settings", "AdvertisingChannelType", "AdvertisingChannelSubType", "Labels", "TrackingUrlTemplate",
+//   "UrlCustomParameters"
+//
+// filterable fields are
+//   "Id", "Name", "Status", "ServingStatus", "StartDate", "EndDate", "AdvertisingChannelType",
+//   "AdvertisingChannelSubType", "Labels", "TrackingUrlTemplate"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#get
+//
+func (s *CampaignService) Get(selector Selector) (campaigns []Campaign, totalCount int64, err error) {
+	// The default namespace, "", will break in 1.5 with the addition of
+	// custom namespace support.  Hence, we have to ensure that the baseUrl is
+	// set again as the proper namespace for the service/serviceSelector element
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+
+	respBody, err := s.Auth.request(
+		campaignServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+	getResp := struct {
+		Size      int64      `xml:"rval>totalNumEntries"`
+		Campaigns []Campaign `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+	return getResp.Campaigns, getResp.Size, err
+}
+
+// Mutate allows you to add and modify campaigns, returning the
+// campaigns.  Note that the "REMOVE" operator is not supported.
+// To remove a campaign set its Status to "REMOVED".
+//
+// Example
+//
+//  campaignNeedingRemoval.Status = "REMOVED"
+//  ads, err := campaignService.Mutate(
+//    gads.CampaignOperations{
+//      "ADD": {
+//        gads.Campaign{
+//          Name: "my campaign name",
+//          Status: "PAUSED",
+//          StartDate: time.Now().Format("20060102"),
+//          BudgetId: 321543214,
+//          AdServingOptimizationStatus: "ROTATE_INDEFINITELY",
+//          Settings: []gads.CampaignSetting{
+//            gads.NewRealTimeBiddingSetting(true),
+//          },
+//          AdvertisingChannelType: "SEARCH",
+//          BiddingStrategyConfiguration: &gads.BiddingStrategyConfiguration{
+//            StrategyType: "MANUAL_CPC",
+//          },
+//        },
+//        campaignNeedingRemoval,
+//      },
+//      "SET": {
+//        modifiedCampaign,
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#mutate
+//
+func (s *CampaignService) Mutate(campaignOperations CampaignOperations) (campaigns []Campaign, err error) {
+	type campaignOperation struct {
+		Action   string   `xml:"operator"`
+		Campaign Campaign `xml:"operand"`
+	}
+	operations := []campaignOperation{}
+	for action, campaigns := range campaignOperations {
+		for _, campaign := range campaigns {
+			operations = append(operations,
+				campaignOperation{
+					Action:   action,
+					Campaign: campaign,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []campaignOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(campaignServiceUrl, "mutate", mutation)
+	if err != nil {
+		return campaigns, err
+	}
+	mutateResp := struct {
+		Campaigns []Campaign `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return campaigns, err
+	}
+
+	return mutateResp.Campaigns, err
+}
+
+// Mutate allows you to add and removes labels from campaigns.
+//
+// Example
+//
+//  cls, err := campaignService.MutateLabel(
+//    gads.CampaignOperations{
+//      "ADD": {
+//        gads.CampaignLabel{CampaignId: 3200, LabelId: 5353},
+//        gads.CampaignLabel{CampaignId: 4320, LabelId: 5643},
+//      },
+//      "REMOVE": {
+//        gads.CampaignLabel{CampaignId: 3653, LabelId: 5653},
+//      },
+//    }
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#mutateLabel
+//
+func (s *CampaignService) MutateLabel(campaignLabelOperations CampaignLabelOperations) (campaignLabels []CampaignLabel, err error) {
+	type campaignLabelOperation struct {
+		Action        string        `xml:"operator"`
+		CampaignLabel CampaignLabel `xml:"operand"`
+	}
+	operations := []campaignLabelOperation{}
+	for action, campaignLabels := range campaignLabelOperations {
+		for _, campaignLabel := range campaignLabels {
+			operations = append(operations,
+				campaignLabelOperation{
+					Action:        action,
+					CampaignLabel: campaignLabel,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []campaignLabelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutateLabel",
+		},
+		Ops: operations}
+	respBody, err := s.Auth.request(campaignServiceUrl, "mutateLabel", mutation)
+	if err != nil {
+		return campaignLabels, err
+	}
+	mutateResp := struct {
+		CampaignLabels []CampaignLabel `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return campaignLabels, err
+	}
+
+	return mutateResp.CampaignLabels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#query
+//
+func (s *CampaignService) Query(query string) (campaigns []Campaign, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		campaignServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+
+	getResp := struct {
+		Size      int64      `xml:"rval>totalNumEntries"`
+		Campaigns []Campaign `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaigns, totalCount, err
+	}
+	return getResp.Campaigns, getResp.Size, err
+}

--- a/v201705/campaign_criterion.go
+++ b/v201705/campaign_criterion.go
@@ -1,0 +1,266 @@
+package v201705
+
+import "encoding/xml"
+
+type CampaignCriterionService struct {
+	Auth
+}
+
+func NewCampaignCriterionService(auth *Auth) *CampaignCriterionService {
+	return &CampaignCriterionService{Auth: *auth}
+}
+
+type CampaignCriterion struct {
+	CampaignId  int64     `xml:"campaignId"`
+	IsNegative  bool      `xml:"isNegative,omitempty"`
+	Criterion   Criterion `xml:"criterion"`
+	BidModifier *float64  `xml:"bidModifier,omitempty"`
+	Errors      []error   `xml:"-"`
+}
+
+func (cc CampaignCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	isNegative := false
+	//fmt.Printf("processing -> %#v\n",ncc)
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"CampaignCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&cc.CampaignId, xml.StartElement{Name: xml.Name{"", "campaignId"}})
+	e.EncodeElement(&isNegative, xml.StartElement{Name: xml.Name{"", "isNegative"}})
+	if err := criterionMarshalXML(cc.Criterion, e); err != nil {
+		return err
+	}
+	if cc.BidModifier != nil {
+		e.EncodeElement(&cc.BidModifier, xml.StartElement{Name: xml.Name{"", "bidModifier"}})
+	}
+
+	e.EncodeToken(start.End())
+	return nil
+}
+
+type NegativeCampaignCriterion struct {
+	CampaignId  int64     `xml:"campaignId"`
+	IsNegative  bool      `xml:"isNegative,omitempty"`
+	Criterion   Criterion `xml:"criterion"`
+	BidModifier *float64  `xml:"bidModifier,omitempty"`
+	Errors      []error   `xml:"-"`
+}
+
+type CampaignCriterions []interface{}
+type CampaignCriterionOperations map[string]CampaignCriterions
+
+func (ncc NegativeCampaignCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	isNegative := true
+	//fmt.Printf("processing -> %#v\n",ncc)
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"NegativeCampaignCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&ncc.CampaignId, xml.StartElement{Name: xml.Name{"", "campaignId"}})
+	e.EncodeElement(&isNegative, xml.StartElement{Name: xml.Name{"", "isNegative"}})
+	criterionMarshalXML(ncc.Criterion, e)
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (ccs *CampaignCriterions) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	cc := NegativeCampaignCriterion{}
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			switch start.Name.Local {
+			case "campaignId":
+				if err := dec.DecodeElement(&cc.CampaignId, &start); err != nil {
+					return err
+				}
+			case "criterion":
+				criterion, err := criterionUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				cc.Criterion = criterion
+			case "bidModifier":
+				if err := dec.DecodeElement(&cc.BidModifier, &start); err != nil {
+					return err
+				}
+			case "isNegative":
+				if err := dec.DecodeElement(&cc.IsNegative, &start); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	*ccs = append(*ccs, cc)
+	return nil
+}
+
+/*
+func NewNegativeCampaignCriterion(campaignId int64, bidModifier float64, criterion interface{}) CampaignCriterion {
+  return CampaignCriterion{
+    CampaignId: campaignId,
+    Criterion: criterion,
+    BidModifier: bidModifier
+  }
+  switch c := criterion.(type) {
+  case AdScheduleCriterion:
+  case AgeRangeCriterion:
+  case ContentLabelCriterion:
+  case GenderCriterion:
+  case KeywordCriterion:
+  case LanguageCriterion:
+  case LocationCriterion:
+  case MobileAppCategoryCriterion:
+  case MobileApplicationCriterion:
+  case MobileDeviceCriterion:
+  case OperatingSystemVersionCriterion:
+  case PlacementCriterion:
+  case PlatformCriterion:
+  case ProductCriterion:
+  case ProximityCriterion:
+  case UserInterestCriterion:
+    cc.Criterion = criterion
+  case UserListCriterion:
+    cc.Criterion = criterion
+  case VerticalCriterion:
+  }
+}
+*/
+
+func (s *CampaignCriterionService) Get(selector Selector) (campaignCriterions CampaignCriterions, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		campaignCriterionServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+	getResp := struct {
+		Size               int64              `xml:"rval>totalNumEntries"`
+		CampaignCriterions CampaignCriterions `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+	return getResp.CampaignCriterions, getResp.Size, err
+}
+
+func (s *CampaignCriterionService) Mutate(campaignCriterionOperations CampaignCriterionOperations) (campaignCriterions CampaignCriterions, err error) {
+	type campaignCriterionOperation struct {
+		Action            string      `xml:"operator"`
+		CampaignCriterion interface{} `xml:"operand"`
+	}
+	operations := []campaignCriterionOperation{}
+	for action, campaignCriterions := range campaignCriterionOperations {
+		for _, campaignCriterion := range campaignCriterions {
+			operations = append(operations,
+				campaignCriterionOperation{
+					Action:            action,
+					CampaignCriterion: campaignCriterion,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []campaignCriterionOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(campaignCriterionServiceUrl, "mutate", mutation)
+	if err != nil {
+		/*
+			    switch t := err.(type) {
+			    case *ErrorsType:
+				    for action, campaignCriterions := range campaignCriterionOperations {
+					    for _, campaignCriterion := range campaignCriterions {
+			          campaignCriterions = append(campaignCriterions,campaignCriterion)
+			        }
+			      }
+			      for _, aef := range t.ApiExceptionFaults {
+			        for _,e := range aef.Errors {
+			          switch et := e.(type) {
+			          case CriterionError:
+			            offset, err := strconv.ParseInt(strings.Trim(et.FieldPath,"abcdefghijklmnop.]["),10,64)
+			            if err != nil {
+			              return CampaignCriterions{}, err
+			            }
+			            cc := campaignCriterions[offset]
+			            switch c := cc.(type) {
+			            case CampaignCriterion:
+			              CampaignCriterion(campaignCriterions[offset]).Errors = append(campaignCriterions[offset].(CampaignCriterion).Errors,fmt.Errorf(et.Reason))
+			            case NegativeCampaignCriterion:
+			              NegativeCampaignCriterion(campaignCriterions[offset]).Errors = append(NegativeCampaignCriterion(campaignCriterions[offset].Errors),fmt.Errorf(et.Reason))
+			            }
+			          }
+			        }
+			      }
+			    default:
+		*/
+		return campaignCriterions, err
+		//}
+	}
+	mutateResp := struct {
+		CampaignCriterions CampaignCriterions `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return campaignCriterions, err
+	}
+	return mutateResp.CampaignCriterions, err
+}
+
+func (s *CampaignCriterionService) Query(query string) (campaignCriterions CampaignCriterions, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		campaignCriterionServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+
+	getResp := struct {
+		Size               int64              `xml:"rval>totalNumEntries"`
+		CampaignCriterions CampaignCriterions `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return campaignCriterions, totalCount, err
+	}
+	return getResp.CampaignCriterions, getResp.Size, err
+}

--- a/v201705/campaign_criterion_test.go
+++ b/v201705/campaign_criterion_test.go
@@ -1,0 +1,41 @@
+package v201705
+
+import (
+	"testing"
+	//  "encoding/xml"
+)
+
+func testCampaignCriterionService(t *testing.T) (service *CampaignCriterionService) {
+	return &CampaignCriterionService{Auth: testAuthSetup(t)}
+}
+
+func TestCampaignCriterion(t *testing.T) {
+	campaign, cleanupCampaign := testCampaign(t)
+	defer cleanupCampaign()
+
+	ccs := testCampaignCriterionService(t)
+	campaignCriterions, err := ccs.Mutate(
+		CampaignCriterionOperations{
+			"ADD": {
+				CampaignCriterion{CampaignId: campaign.Id, Criterion: AdScheduleCriterion{DayOfWeek: "MONDAY", StartHour: "10", StartMinute: "ZERO", EndHour: "13", EndMinute: "ZERO"}},
+				CampaignCriterion{CampaignId: campaign.Id, Criterion: Location{Id: 2392}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+				NegativeCampaignCriterion{CampaignId: campaign.Id, Criterion: KeywordCriterion{Text: rand_str(10), MatchType: "EXACT"}},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//t.Fatalf("%#v\n",campaignCriterions)
+
+	defer func() {
+		_, err = ccs.Mutate(CampaignCriterionOperations{"REMOVE": campaignCriterions})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+}

--- a/v201705/campaign_extension.go
+++ b/v201705/campaign_extension.go
@@ -1,0 +1,95 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type CampaignExtensionSettingService struct {
+	Auth
+}
+
+func NewCampaignExtensionService(auth *Auth) *CampaignExtensionSettingService {
+	return &CampaignExtensionSettingService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/CampaignExtensionSettingService.CampaignExtensionSetting
+// A CampaignExtensionSetting is used to add or modify extensions being served for the specified campaign.
+type CampaignExtensionSetting struct {
+	CampaignId       int64            `xml:"https://adwords.google.com/api/adwords/cm/v201705 campaignId,omitempty"`
+	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201705 extensionType,omitempty"`
+	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201705 extensionSetting,omitempty"`
+}
+
+type CampaignExtensionSettingOperations map[string][]CampaignExtensionSetting
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/CampaignExtensionSettingService#query
+func (s *CampaignExtensionSettingService) Query(query string) (settings []CampaignExtensionSetting, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		campaignExtensionSettingUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	getResp := struct {
+		Size     int64                      `xml:"rval>totalNumEntries"`
+		Settings []CampaignExtensionSetting `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal(respBody, &getResp)
+	if err != nil {
+		return
+	}
+	return getResp.Settings, getResp.Size, err
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/CampaignExtensionSettingService#mutate
+func (s *CampaignExtensionSettingService) Mutate(settingsOperations CampaignExtensionSettingOperations) (settings []CampaignExtensionSetting, err error) {
+	type settingOperations struct {
+		Action  string                   `xml:"operator"`
+		Setting CampaignExtensionSetting `xml:"operand"`
+	}
+	operations := []settingOperations{}
+	for action, settings := range settingsOperations {
+		for _, setting := range settings {
+			operations = append(operations,
+				settingOperations{
+					Action:  action,
+					Setting: setting,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []settingOperations `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+
+	respBody, err := s.Auth.request(campaignExtensionSettingUrl, "mutate", mutation)
+	if err != nil {
+		return settings, err
+	}
+	mutateResp := struct {
+		Settings []CampaignExtensionSetting `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal(respBody, &mutateResp)
+	if err != nil {
+		return settings, err
+	}
+
+	return mutateResp.Settings, err
+}

--- a/v201705/campaign_feed.go
+++ b/v201705/campaign_feed.go
@@ -1,0 +1,9 @@
+package v201705
+
+type CampaignFeedService struct {
+	Auth
+}
+
+func NewCampaignFeedService(auth *Auth) *CampaignFeedService {
+	return &CampaignFeedService{Auth: *auth}
+}

--- a/v201705/campaign_management_test.go
+++ b/v201705/campaign_management_test.go
@@ -1,0 +1,3 @@
+package v201705
+
+import ()

--- a/v201705/campaign_shared_set.go
+++ b/v201705/campaign_shared_set.go
@@ -1,0 +1,9 @@
+package v201705
+
+type CampaignSharedSetService struct {
+	Auth
+}
+
+func NewCampaignSharedSetService(auth *Auth) *CampaignSharedSetService {
+	return &CampaignSharedSetService{Auth: *auth}
+}

--- a/v201705/campaign_test.go
+++ b/v201705/campaign_test.go
@@ -1,0 +1,156 @@
+package v201705
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func testCampaignService(t *testing.T) (service *CampaignService) {
+	return &CampaignService{Auth: testAuthSetup(t)}
+}
+
+func testCampaign(t *testing.T) (Campaign, func()) {
+	budget, cleanupBudget := testBudget(t)
+	cs := testCampaignService(t)
+	campaigns, err := cs.Mutate(
+		CampaignOperations{
+			"ADD": {
+				Campaign{
+					Name:                        "test campaign " + rand_str(10),
+					Status:                      "PAUSED",
+					StartDate:                   time.Now().Format("20060102"),
+					BudgetId:                    budget.Id,
+					AdServingOptimizationStatus: "ROTATE_INDEFINITELY",
+					Settings: []CampaignSetting{
+						NewRealTimeBiddingSetting(true),
+					},
+					AdvertisingChannelType: "SEARCH",
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupCampaign := func() {
+		campaigns[0].Status = "REMOVED"
+		_, err = cs.Mutate(CampaignOperations{"SET": campaigns})
+		if err != nil {
+			t.Error(err)
+		}
+		cleanupBudget()
+	}
+	return campaigns[0], cleanupCampaign
+}
+
+func TestCampaign(t *testing.T) {
+	budget, cleanupBudget := testBudget(t)
+	defer cleanupBudget()
+
+	cs := testCampaignService(t)
+	campaigns, err := cs.Mutate(
+		CampaignOperations{
+			"ADD": {
+				Campaign{
+					Name:                        "test campaign " + rand_str(10),
+					Status:                      "PAUSED",
+					StartDate:                   time.Now().Format("20060102"),
+					BudgetId:                    budget.Id,
+					AdServingOptimizationStatus: "ROTATE_INDEFINITELY",
+					Settings: []CampaignSetting{
+						NewRealTimeBiddingSetting(true),
+					},
+					AdvertisingChannelType: "SEARCH",
+					NetworkSetting: &NetworkSetting{
+						TargetGoogleSearch:         true,
+						TargetSearchNetwork:        true,
+						TargetContentNetwork:       false,
+						TargetPartnerSearchNetwork: false,
+					},
+					BiddingStrategyConfiguration: &BiddingStrategyConfiguration{
+						StrategyType: "MANUAL_CPC",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func(campaigns []Campaign) {
+		campaigns[0].Status = "REMOVED"
+		_, err = cs.Mutate(CampaignOperations{"SET": campaigns})
+		if err != nil {
+			t.Error(err)
+		}
+	}(campaigns)
+
+	label, labelCleanup := testLabel(t)
+	defer labelCleanup()
+
+	campaignLabels, err := cs.MutateLabel(
+		CampaignLabelOperations{
+			"ADD": {
+				CampaignLabel{CampaignId: campaigns[0].Id, LabelId: label.Id},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		campaignLabels, err = cs.MutateLabel(CampaignLabelOperations{"REMOVE": campaignLabels})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	foundCampaigns, _, err := cs.Get(
+		Selector{
+			Fields: []string{
+				"Id",
+				"Name",
+				"Status",
+				"ServingStatus",
+				"StartDate",
+				"EndDate",
+				"AdServingOptimizationStatus",
+				"Settings",
+				"Labels",
+			},
+			Predicates: []Predicate{
+				{"Status", "EQUALS", []string{"PAUSED"}},
+			},
+			Ordering: []OrderBy{
+				{"Id", "ASCENDING"},
+			},
+			Paging: &Paging{
+				Offset: 0,
+				Limit:  100,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("found %d campaigns\n", len(foundCampaigns))
+	for _, c := range campaigns {
+		func(campaign Campaign) {
+			for _, foundCampaign := range foundCampaigns {
+				if foundCampaign.Id == campaign.Id {
+					fmt.Printf("%#v", foundCampaign)
+					return
+				}
+			}
+			t.Errorf("campaign %d not found in \n%#v\n", campaign.Id, foundCampaigns)
+		}(c)
+	}
+
+}

--- a/v201705/cli/adgroups_awql.go
+++ b/v201705/cli/adgroups_awql.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// show all Campaigns
+	cs := gads.NewAdGroupService(&config.Auth)
+	fmt.Printf("AdGroups\n")
+
+	foundAdGroups, totalCount, err := cs.Query("SELECT AdGroupId, Name, Status WHERE CampaignId = '123'")
+	fmt.Println(totalCount)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, adGroup := range foundAdGroups {
+		adGroupJSON, _ := json.MarshalIndent(adGroup, "", "  ")
+		fmt.Printf("%s\n", adGroupJSON)
+	}
+
+}

--- a/v201705/cli/batch_job.go
+++ b/v201705/cli/batch_job.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+	"strconv"
+	"time"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// Your campaign ID should go here
+var campaignId int64 = 1234567890
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Batch Job
+	bs := gads.NewBatchJobService(&config.Auth)
+
+	/*ago := gads.AdGroupCriterionOperations{
+	"SET":	gads.AdGroupCriterions {
+				gads.BiddableAdGroupCriterion{
+					AdGroupId: 11400713462,
+					Criterion: gads.KeywordCriterion{
+						Id: 47652524966,
+					},
+					BiddingStrategyConfiguration: &gads.BiddingStrategyConfiguration{
+						Bids: []gads.Bid{
+							gads.Bid{
+								Type:   "CpcBid",
+								Amount: 5372200,
+							},
+						},
+					},
+					UrlCustomParameters: gads.CustomParameters{
+						CustomParameters: []gads.CustomParameter{
+							gads.CustomParameter{
+								Key:      "foo",
+								Value:    "bar",
+								IsRemove: false,
+							},
+						},
+						DoReplace: false,
+					},
+				},
+				gads.BiddableAdGroupCriterion{
+					AdGroupId: 11400713462,
+					Criterion: gads.KeywordCriterion{
+						Id: 47652524366,
+					},
+					BiddingStrategyConfiguration: &gads.BiddingStrategyConfiguration{
+						Bids: []gads.Bid{
+							gads.Bid{
+								Type:   "CpcBid",
+								Amount: 5372200,
+							},
+						},
+					},
+					UrlCustomParameters: gads.CustomParameters{
+						CustomParameters: []gads.CustomParameter{
+							gads.CustomParameter{
+								Key:      "foo",
+								Value:    "bar",
+								IsRemove: false,
+							},
+						},
+						DoReplace: false,
+					},
+				},
+			},
+	}*/
+	// Creating AdGroups
+	ago := gads.AdGroupOperations{
+		"ADD": {},
+	}
+
+	// stress test uploading
+	var adGroupNum int = 10000
+
+	for i := 0; i < adGroupNum; i++ {
+		ago["ADD"] = append(ago["ADD"], gads.AdGroup{
+			Name:       "test ad group " + rand_str(10),
+			Status:     "PAUSED",
+			CampaignId: campaignId,
+		})
+	}
+
+	var operations []interface{}
+	operations = append(operations, ago)
+
+	bjo := gads.BatchJobOperations{
+		BatchJobOperations: []gads.BatchJobOperation{
+			gads.BatchJobOperation{
+				Operator: "ADD",
+				Operand:  gads.BatchJob{},
+			},
+		},
+	}
+
+	if resp, err := bs.Mutate(bjo); err == nil {
+
+		bjh := gads.NewBatchJobHelper(&config.Auth)
+		err = bjh.UploadBatchJobOperations(operations, *resp[0].UploadUrl)
+
+		if err != nil {
+			panic(err)
+		}
+
+		jobId := resp[0].Id
+		batchJobs := gads.BatchJobPage{}
+
+		// loop
+		for {
+			// recheck every 5 seconds
+			time.Sleep(5 * time.Second)
+			selector := gads.Selector{
+				Fields: []string{
+					"Id",
+					"Status",
+					"DownloadUrl",
+					"ProcessingErrors",
+					"ProgressStats",
+				},
+				Predicates: []gads.Predicate{
+					{"Id", "EQUALS", []string{strconv.FormatInt(jobId, 10)}},
+				},
+			}
+
+			// more than likely you'll want to have some logic to loop through these if you have multiple batch jobs, but since only one we just want to grab the first one
+			batchJobs, err = bs.Get(selector)
+
+			if err != nil {
+				panic(err)
+			}
+
+			if batchJobs.BatchJobs[0].Status == "DONE" {
+				break
+			} else if batchJobs.BatchJobs[0].Status == "CANCELED" {
+				panic("Job was canceled")
+			}
+		}
+
+		if batchJobs.BatchJobs[0].DownloadUrl.Url != "" {
+			// get the job
+			mutateResult, err := bjh.DownloadBatchJob(*batchJobs.BatchJobs[0].DownloadUrl)
+
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Println(mutateResult)
+			jsonResult, _ := json.Marshal(mutateResult)
+
+			fmt.Println(string(jsonResult))
+		}
+	} else {
+		// handle err
+		panic(err)
+	}
+
+}
+
+func rand_str(str_size int) string {
+	alphanum := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}

--- a/v201705/cli/bid_landscape.go
+++ b/v201705/cli/bid_landscape.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// Your IDs should go here
+var campaignId string = "1234567890"
+var adGroupId string = "1234567890"
+var criterionId string = "1234567890"
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	service := gads.NewDataService(&config.Auth)
+
+	// Test GetAdGroupBidLandscape
+
+	adGroupBidLandscape, _, err := service.GetAdGroupBidLandscape(
+		gads.Selector{
+			Fields: []string{
+				"AdGroupId",
+				"Bid",
+				"CampaignId",
+				"LocalClicks",
+				"LocalCost",
+				"LocalImpressions",
+				"PromotedImpressions",
+				"StartDate",
+				"EndDate",
+			},
+			Predicates: []gads.Predicate{
+				{"AdGroupId", "EQUALS", []string{adGroupId}},
+			},
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range adGroupBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test GetAdGroupBidLandscape
+
+	// Test QueryAdGroupBidLandscape
+
+	foundBidLandscape, _, err := service.QueryAdGroupBidLandscape(fmt.Sprintf("SELECT AdGroupId, Bid, CampaignId, LocalClicks, LocalCost, LocalImpressions WHERE AdGroupId = '%v'", adGroupId))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range foundBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test QueryAdGroupBidLandscape
+
+	// Test GetCriterionBidLandscape
+
+	criterionBidLandscape, _, err := service.GetCriterionBidLandscape(
+		gads.Selector{
+			Fields: []string{
+				"AdGroupId",
+				"Bid",
+				"CampaignId",
+				"CriterionId",
+				"LocalClicks",
+				"LocalCost",
+				"LocalImpressions",
+				"PromotedImpressions",
+				"StartDate",
+				"EndDate",
+			},
+			Predicates: []gads.Predicate{
+				{"CriterionId", "EQUALS", []string{criterionId}},
+				{"AdGroupId", "EQUALS", []string{adGroupId}},
+			},
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range criterionBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test GetCriterionBidLandscape
+
+	// Test QueryCriterionBidLandscape
+
+	queryCriterionBidLandscape, _, err := service.QueryCriterionBidLandscape(fmt.Sprintf("SELECT AdGroupId, Bid, CampaignId, CriterionId, LocalClicks, LocalCost, LocalImpressions WHERE AdGroupId = '%v' AND CriterionId = '%v'", adGroupId, criterionId))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, bidLandscape := range queryCriterionBidLandscape {
+		landscapeJSON, _ := json.MarshalIndent(bidLandscape, "", "  ")
+		fmt.Printf("%s\n", landscapeJSON)
+	}
+
+	// END Test QueryCriterionBidLandscape
+
+}

--- a/v201705/cli/campaign_criterion.go
+++ b/v201705/cli/campaign_criterion.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cs := gads.NewCampaignCriterionService(&config.Auth)
+
+	//bidmodifier := float64(2)
+	//var bidmodifier float64
+	//bidmodifier = 1.04
+
+	campaignCriterions := gads.CampaignCriterions{
+		gads.NegativeCampaignCriterion{
+			CampaignId: 123456789,
+			Criterion: gads.Location{
+				Id: 21168,
+			},
+		},
+		gads.CampaignCriterion{
+			CampaignId: 123456789,
+			Criterion: gads.Location{
+				Id: 21167,
+			},
+		},
+	}
+
+	criterions, err := cs.Mutate(
+		gads.CampaignCriterionOperations{
+			"ADD": campaignCriterions,
+		},
+	)
+
+	fmt.Println(criterions)
+	criterionJSON, _ := json.MarshalIndent(criterions, "", "  ")
+	fmt.Printf("%s\n", criterionJSON)
+
+	// show all Location Criterion
+	fmt.Printf("Campaign Criterion\n")
+	foundCriterions, totalCount, err := cs.Query("SELECT CampaignId,IsNegative,BidModifier,CriteriaType,Id,LocationName,DisplayType,ParentLocations WHERE CampaignId = '211793582' AND CriteriaType IN ['LOCATION']")
+	fmt.Println(totalCount)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, criterion := range foundCriterions {
+		criterionJSON, _ := json.MarshalIndent(criterion, "", "  ")
+		fmt.Printf("%s\n", criterionJSON)
+	}
+
+}

--- a/v201705/cli/campaigns.go
+++ b/v201705/cli/campaigns.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/colinmutter/gads/v201705"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+func main() {
+	config, err := gads.NewCredentials(oauth2.NoContext)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var pageSize int64 = 500
+	var offset int64
+
+	// show all Campaigns
+	cs := gads.NewCampaignService(&config.Auth)
+	paging := gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nCampaigns\n")
+	for {
+		foundCampaigns, totalCount, err := cs.Get(
+			gads.Selector{
+				Fields: []string{
+					"Id",
+					"Name",
+					"Status",
+					"ServingStatus",
+					"StartDate",
+					"EndDate",
+					"AdServingOptimizationStatus",
+					"Settings",
+					"AdvertisingChannelType",
+					"AdvertisingChannelSubType",
+					"Labels",
+					"TrackingUrlTemplate",
+					"UrlCustomParameters",
+				},
+				Predicates: []gads.Predicate{
+					{"Status", "EQUALS", []string{"PAUSED"}},
+				},
+				Ordering: []gads.OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, campaign := range foundCampaigns {
+			campaignJson, _ := json.MarshalIndent(campaign, "", "  ")
+			fmt.Printf("%s\n", campaignJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+}

--- a/v201705/cli/cli.go
+++ b/v201705/cli/cli.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+func main() {
+	config, err := gads.NewCredentials(oauth2.NoContext)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bs := gads.NewBudgetService(&config.Auth)
+
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nBudgets\n")
+	for {
+		foundBudgets, totalCount, err := bs.Get(gads.Selector{
+			Fields: []string{
+				"BudgetId",
+				"BudgetName",
+				"Period",
+				"Amount",
+				"DeliveryMethod",
+				"BudgetReferenceCount",
+				"IsBudgetExplicitlyShared",
+				"BudgetStatus",
+			},
+			Paging: &paging,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, budget := range foundBudgets {
+			budgetJson, _ := json.MarshalIndent(budget, "", "  ")
+			fmt.Printf("  %s\n", string(budgetJson))
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+	// show all Campaigns
+	cs := gads.NewCampaignService(&config.Auth)
+	offset = 0
+	paging = gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nCampaigns\n")
+	for {
+		foundCampaigns, totalCount, err := cs.Get(
+			gads.Selector{
+				Fields: []string{
+					"Id",
+					"BudgetId",
+					"Name",
+					"Status",
+					"ServingStatus",
+					"StartDate",
+					"EndDate",
+					"AdServingOptimizationStatus",
+					"Settings",
+					"AdvertisingChannelType",
+					"AdvertisingChannelSubType",
+					"Labels",
+					"TrackingUrlTemplate",
+					"UrlCustomParameters",
+				},
+				Predicates: []gads.Predicate{
+					{"Status", "EQUALS", []string{"PAUSED"}},
+				},
+				Ordering: []gads.OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, campaign := range foundCampaigns {
+			campaignJson, _ := json.MarshalIndent(campaign, "", "  ")
+			fmt.Printf("%s\n", campaignJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+	ags := gads.NewAdGroupService(&config.Auth)
+	offset = 0
+	paging = gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nAdGroups\n")
+	for {
+		foundAdGroups, totalCount, err := ags.Get(
+			gads.Selector{
+				Fields: []string{
+					"Id",
+					"CampaignId",
+					"CampaignName",
+					"Name",
+					"Status",
+					"Settings",
+					"ContentBidCriterionTypeGroup",
+				},
+				Predicates: []gads.Predicate{
+					{"Status", "EQUALS", []string{"PAUSED"}},
+				},
+				Ordering: []gads.OrderBy{
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, adGroup := range foundAdGroups {
+			adGroupJson, _ := json.MarshalIndent(adGroup, "", "  ")
+			fmt.Printf("%#v\n", adGroupJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+
+	agas := gads.NewAdGroupAdService(&config.Auth)
+	offset = 0
+	paging = gads.Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	fmt.Printf("\nAds\n")
+	for {
+		foundAds, totalCount, err := agas.Get(
+			gads.Selector{
+				Fields: []string{
+					"AdGroupId",
+					"Status",
+					"AdGroupCreativeApprovalStatus",
+					"AdGroupAdDisapprovalReasons",
+					"AdGroupAdTrademarkDisapproved",
+				},
+				Ordering: []gads.OrderBy{
+					{"AdGroupId", "ASCENDING"},
+					{"Id", "ASCENDING"},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, ad := range foundAds {
+			adJson, _ := json.MarshalIndent(ad, "", "  ")
+			fmt.Printf("%s\n", adJson)
+		}
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			break
+		}
+	}
+}

--- a/v201705/cli/crm_based_user_list.go
+++ b/v201705/cli/crm_based_user_list.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// Your campaign ID should go here
+var campaignId int64 = 1234567890
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// User List Service
+	auls := gads.NewAdwordsUserListService(&config.Auth)
+
+	crmList := gads.NewCrmBasedUserList("Test List", "Just a list to test with", 0, "http://mytest.com/optout")
+
+	ops := gads.UserListOperations{
+		Operations: []gads.Operation{
+			gads.Operation{
+				Operator: "ADD",
+				Operand:  crmList,
+			},
+		},
+	}
+
+	resp, err := auls.Mutate(ops)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(resp[0].Id)
+
+	mmo := gads.NewMutateMembersOperand()
+	mmo.UserListId = resp[0].Id
+
+	var members []string
+	members = append(members, "brian@test.com")
+	members = append(members, "test@test.com")
+
+	mmo.Members = members
+
+	mutateMembersOperations := gads.MutateMembersOperations{
+		Operations: []gads.Operation{
+			gads.Operation{
+				Operator: "ADD",
+				Operand:  mmo,
+			},
+		},
+	}
+
+	lists, err := auls.MutateMembers(mutateMembersOperations)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(lists)
+}

--- a/v201705/cli/customer_service.go
+++ b/v201705/cli/customer_service.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cs := gads.NewCustomerService(&config.Auth)
+
+	customers, err := cs.GetCustomers()
+
+	fmt.Println(customers)
+	customersJSON, err := json.MarshalIndent(customers, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", customersJSON)
+
+}

--- a/v201705/cli/expanded_text_ad.go
+++ b/v201705/cli/expanded_text_ad.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	aga := gads.NewAdGroupAdService(&config.Auth)
+
+	ads, err := aga.Mutate(
+		gads.AdGroupAdOperations{
+			"ADD": {
+				gads.ExpandedTextAd{
+					AdGroupId:     1234567890,
+					FinalUrls:     []string{"https://classdo.com/en"},
+					Path1:         "path1",
+					Path2:         "path2",
+					HeadlinePart1: "test headline",
+					HeadlinePart2: "test headline2",
+					Description:   "test line one",
+				},
+			},
+		},
+	)
+
+	fmt.Println(ads)
+	adsJSON, err := json.MarshalIndent(ads, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", adsJSON)
+
+}

--- a/v201705/cli/flush.go
+++ b/v201705/cli/flush.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"crypto/rand"
+	"github.com/colinmutter/gads/v201705"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+func rand_str(str_size int) string {
+	alphanum := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, str_size)
+	rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return string(bytes)
+}
+
+func main() {
+	config, err := gads.NewCredentials(oauth2.NoContext)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ags := gads.NewAdGroupService(config.Auth)
+	foundAdGroups, err := ags.Get(
+		gads.Selector{
+			Fields: []string{
+				"Id",
+				"CampaignId",
+				"CampaignName",
+				"Name",
+				"Status",
+				"Settings",
+				"ContentBidCriterionTypeGroup",
+			},
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for idx, _ := range foundAdGroups {
+		foundAdGroups[idx].Status = "REMOVED"
+		foundAdGroups[idx].Name = rand_str(20)
+	}
+
+	_, err = ags.Mutate(gads.AdGroupOperations{"SET": foundAdGroups})
+
+	// Remove all Campaigns
+	cs := gads.NewCampaignService(config.Auth)
+	foundCampaigns, err := cs.Get(
+		gads.Selector{
+			Fields: []string{
+				"Id",
+				"BudgetId",
+				"Name",
+				"Status",
+				"ServingStatus",
+				"StartDate",
+				"EndDate",
+				"AdServingOptimizationStatus",
+				"Settings",
+			},
+			Ordering: []gads.OrderBy{
+				{"Id", "ASCENDING"},
+			},
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	for idx, _ := range foundCampaigns {
+		foundCampaigns[idx].Status = "REMOVED"
+		foundCampaigns[idx].Name = rand_str(20)
+	}
+	_, err = cs.Mutate(gads.CampaignOperations{"SET": foundCampaigns})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Remove all budgets
+	bs := gads.NewBudgetService(config.Auth)
+	foundBudgets, err := bs.Get(gads.Selector{Fields: []string{"BudgetId", "BudgetName", "Period", "Amount", "DeliveryMethod"}})
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = bs.Mutate(gads.BudgetOperations{"REMOVE": foundBudgets})
+	if err != nil {
+		log.Printf("%#v\n", err)
+		log.Fatal(err)
+	}
+}

--- a/v201705/cli/keywords_awql.go
+++ b/v201705/cli/keywords_awql.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// show all Keywords
+	cs := gads.NewAdGroupCriterionService(&config.Auth)
+	fmt.Printf("Keywords\n")
+	foundKeywords, totalCount, err := cs.Query("SELECT Id, KeywordText, KeywordMatchType WHERE AdGroupId = '123'")
+	fmt.Println(totalCount)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, keyword := range foundKeywords {
+		keywordJSON, _ := json.MarshalIndent(keyword, "", "  ")
+		fmt.Printf("%s\n", keywordJSON)
+	}
+
+}

--- a/v201705/cli/partial_failure.go
+++ b/v201705/cli/partial_failure.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config.Auth.PartialFailure = true
+
+	service := gads.NewAdGroupService(&config.Auth)
+
+	adGroupList := []gads.AdGroupLabel{
+		gads.AdGroupLabel{
+			AdGroupId: 1234567890,
+			LabelId:   1234567,
+		},
+		gads.AdGroupLabel{
+			AdGroupId: 1234567891,
+			LabelId:   1234567,
+		},
+		gads.AdGroupLabel{
+			AdGroupId: 1234567892,
+			LabelId:   1234567,
+		},
+	}
+
+	adGroupLabels, err := service.MutateLabel(
+		gads.AdGroupLabelOperations{
+			"ADD": adGroupList,
+		},
+	)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(adGroupLabels)
+
+}

--- a/v201705/cli/report.go
+++ b/v201705/cli/report.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+// The query you want to run
+var awql string = "Select AdGroupId,Id,CreativeQualityScore,PostClickQualityScore,SearchPredictedCtr,QualityScore FROM KEYWORDS_PERFORMANCE_REPORT DURING YESTERDAY"
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Report Service
+	rs := gads.NewReportDownloadService(&config.Auth)
+
+	res, err := rs.AWQL(awql, "CSV")
+
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	log.Println(res)
+}

--- a/v201705/cli/targeting_idea.go
+++ b/v201705/cli/targeting_idea.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	gads "github.com/colinmutter/gads/v201705"
+	"log"
+)
+
+var configJson = flag.String("oauth", "./oauth.json", "API credentials")
+
+func main() {
+	flag.Parse()
+	config, err := gads.NewCredentialsFromFile(*configJson)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tis := gads.NewTargetingIdeaService(&config.Auth)
+
+	ads, _, err := tis.Get(
+		gads.TargetingIdeaSelector{
+			IdeaType:    "KEYWORD",
+			RequestType: "IDEAS",
+			RequestedAttributeTypes: []string{
+				"CATEGORY_PRODUCTS_AND_SERVICES",
+				"COMPETITION",
+				"EXTRACTED_FROM_WEBPAGE",
+				"IDEA_TYPE",
+				"KEYWORD_TEXT",
+				"SEARCH_VOLUME",
+				"AVERAGE_CPC",
+				"TARGETED_MONTHLY_SEARCHES",
+			},
+			SearchParameters: []gads.SearchParameter{
+				gads.CategoryProductsAndServicesSearchParameter{
+					CategoryID: 51,
+				},
+				gads.CompetitionSearchParameter{
+					Levels: []string{"MEDIUM", "HIGH"},
+				},
+				gads.IdeaTextFilterSearchParameter{
+					Included: []string{},
+					Excluded: []string{"red herring e3a2b4b7", "red herring 418f2d72"},
+				},
+				gads.IncludeAdultContentSearchParameter{},
+				gads.LanguageSearchParameter{
+					Languages: []gads.LanguageCriterion{
+						gads.LanguageCriterion{Id: 1000},
+					},
+				},
+				gads.LocationSearchParameter{
+					Locations: []gads.Location{
+						gads.Location{Id: 2840},
+						gads.Location{Id: 2124},
+					},
+				},
+				gads.NetworkSearchParameter{
+					NetworkSetting: gads.NetworkSetting{
+						TargetGoogleSearch: true,
+					},
+				},
+				gads.RelatedToQuerySearchParameter{
+					Queries: []string{"blue herring", "test"},
+				},
+				gads.RelatedToUrlSearchParameter{
+					Urls: []string{"https://google.com"},
+				},
+				gads.SearchVolumeSearchParameter{
+					Minimum: 3900000,
+					Maximum: 5445394,
+				},
+				// gads.SeedAdGroupIdSearchParameter{
+				// 	AdGroupID: 123456,
+				// },
+			},
+			Paging: gads.Paging{
+				Offset: 0,
+				Limit:  3,
+			},
+		},
+	)
+
+	fmt.Println(ads)
+	adsJSON, err := json.MarshalIndent(ads, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", adsJSON)
+
+}

--- a/v201705/constant_data.go
+++ b/v201705/constant_data.go
@@ -1,0 +1,209 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type ConstantDataService struct {
+	Auth
+}
+
+func NewConstantDataService(auth *Auth) *ConstantDataService {
+	return &ConstantDataService{Auth: *auth}
+}
+
+func (s *ConstantDataService) GetAgeRangeCriterion() (ageRanges []AgeRangeCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getAgeRangeCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getAgeRangeCriterion"`
+		}{},
+	)
+	if err != nil {
+		return ageRanges, err
+	}
+	getResp := struct {
+		AgeRangeCriterions []AgeRangeCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return ageRanges, err
+	}
+	return getResp.AgeRangeCriterions, err
+}
+
+func (s *ConstantDataService) GetCarrierCriterion() (carriers []CarrierCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getCarrierCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getCarrierCriterion"`
+		}{},
+	)
+	if err != nil {
+		return carriers, err
+	}
+	getResp := struct {
+		CarrierCriterions []CarrierCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return carriers, err
+	}
+	return getResp.CarrierCriterions, err
+}
+
+func (s *ConstantDataService) GetGenderCriterion() (genders []GenderCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getGenderCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getGenderCriterion"`
+		}{},
+	)
+	if err != nil {
+		return genders, err
+	}
+	getResp := struct {
+		GenderCriterions []GenderCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return genders, err
+	}
+	return getResp.GenderCriterions, err
+}
+
+func (s *ConstantDataService) GetLanguageCriterion() (languages []LanguageCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getLanguageCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getLanguageCriterion"`
+		}{},
+	)
+	if err != nil {
+		return languages, err
+	}
+	getResp := struct {
+		LanguageCriterions []LanguageCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return languages, err
+	}
+	return getResp.LanguageCriterions, err
+}
+
+func (s *ConstantDataService) GetMobileDeviceCriterion() (mobileDevices []MobileDeviceCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getMobileDeviceCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getMobileDeviceCriterion"`
+		}{},
+	)
+	if err != nil {
+		return mobileDevices, err
+	}
+	getResp := struct {
+		MobileDeviceCriterions []MobileDeviceCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return mobileDevices, err
+	}
+	return getResp.MobileDeviceCriterions, err
+}
+
+func (s *ConstantDataService) GetOperatingSystemVersionCriterion() (operatingSystemVersions []OperatingSystemVersionCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getOperatingSystemVersionCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getOperatingSystemVersionCriterion"`
+		}{},
+	)
+	if err != nil {
+		return operatingSystemVersions, err
+	}
+	getResp := struct {
+		OperatingSystemVersionCriterions []OperatingSystemVersionCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return operatingSystemVersions, err
+	}
+	return getResp.OperatingSystemVersionCriterions, err
+}
+
+func (s *ConstantDataService) GetProductBiddingCategoryCriterion(selector Selector) (categoryData []ProductBiddingCategoryData, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getProductBiddingCategoryData",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: "https://adwords.google.com/api/adwords/cm/v201705",
+				Local: "getProductBiddingCategoryData",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return categoryData, err
+	}
+	getResp := struct {
+		ProductBiddingCategoryDatas []ProductBiddingCategoryData `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return categoryData, err
+	}
+	return getResp.ProductBiddingCategoryDatas, err
+}
+
+func (s *ConstantDataService) GetUserInterestCriterion() (userInterests []UserInterestCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getUserInterestCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getUserInterestCriterion"`
+		}{},
+	)
+	if err != nil {
+		return userInterests, err
+	}
+	getResp := struct {
+		UserInterestCriterions []UserInterestCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return userInterests, err
+	}
+	return getResp.UserInterestCriterions, err
+}
+
+func (s *ConstantDataService) GetVerticalCriterion() (verticals []VerticalCriterion, err error) {
+	respBody, err := s.Auth.request(
+		constantDataServiceUrl,
+		"getVerticalCriterion",
+		struct {
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201705 getVerticalCriterion"`
+		}{},
+	)
+	if err != nil {
+		return verticals, err
+	}
+	getResp := struct {
+		VerticalCriterions []VerticalCriterion `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return verticals, err
+	}
+	return getResp.VerticalCriterions, err
+}

--- a/v201705/constant_data_test.go
+++ b/v201705/constant_data_test.go
@@ -1,0 +1,89 @@
+package v201705
+
+import (
+	//"fmt"
+	"testing"
+)
+
+func testConstantDataService(t *testing.T) (service *ConstantDataService) {
+	return &ConstantDataService{Auth: testAuthSetup(t)}
+}
+
+func TestConstantData(t *testing.T) {
+	/*
+			cds := testConstantDataService(t)
+
+			ageRangeCriterions, err := cds.GetAgeRangeCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("Age Range\n")
+		  for _, ageRange := range ageRangeCriterions {
+		    //fmt.Printf("%d. %s\n",ageRange.Id,ageRange.AgeRangeType)
+		    fmt.Printf("%d. %#v\n",ageRange.Id,ageRange)
+		  }
+
+			carrierCriterions, err := cds.GetCarrierCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nCarrier\n")
+		  for _, carrier := range carrierCriterions {
+		    fmt.Printf("%d. %s,%s\n",carrier.Id, carrier.Name,carrier.CountryCode)
+		  }
+
+			genderCriterions, err := cds.GetGenderCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nGender\n")
+		  for _, gender := range genderCriterions {
+		    fmt.Printf("%d. %s\n",gender.Id, gender.GenderType)
+		  }
+
+			languageCriterions, err := cds.GetLanguageCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nLanguage\n")
+		  for _, language := range languageCriterions {
+		    fmt.Printf("%d. %s,%s\n", language.Id, language.Code, language.Name)
+		  }
+
+			mobileDeviceCriterions, err := cds.GetMobileDeviceCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nMobile Device\n")
+		  for _, mobile := range mobileDeviceCriterions {
+		    fmt.Printf("%d. %s,%s\n", mobile.Id, mobile.DeviceName, mobile.DeviceType)
+		  }
+
+			operatingSystemVersionCriterions, err := cds.GetOperatingSystemVersionCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nOperating System Version\n")
+		  for _, osv := range operatingSystemVersionCriterions {
+		    fmt.Printf("%d. %s,%s\n", osv.Id, osv.Name, osv.OperatorType)
+		  }
+
+			userInterestCriterions, err := cds.GetUserInterestCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nUser Interest\n")
+		  for _, userInterest := range userInterestCriterions {
+		    fmt.Printf("%d. %s\n", userInterest.Id, userInterest.Name)
+		  }
+
+			verticalCriterions, err := cds.GetVerticalCriterion()
+		  if err != nil {
+		    t.Error(err)
+		  }
+		  fmt.Printf("\nVertical\n")
+		  for _, vertical := range verticalCriterions {
+		    fmt.Printf("%d. %#v\n",vertical.Id, vertical.Path)
+		  }
+	*/
+}

--- a/v201705/conversion_tracker.go
+++ b/v201705/conversion_tracker.go
@@ -1,0 +1,14 @@
+package v201705
+
+type ConversionTrackingSettings struct {
+	EffectiveConversionTrackingId      int64 `xml:effectiveConversionTrackingId`
+	UsesCrossAccountConversionTracking bool  `xml:usesCrossAccountConversionTracking`
+}
+
+type ConversionTrackerService struct {
+	Auth
+}
+
+func NewConversionTrackerService(auth *Auth) *ConversionTrackerService {
+	return &ConversionTrackerService{Auth: *auth}
+}

--- a/v201705/criterion.go
+++ b/v201705/criterion.go
@@ -1,0 +1,418 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// DayOfWeek: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+// StartHour: 0~23 inclusive
+// StartMinute: ZERO, FIFTEEN, THIRTY, FORTY_FIVE
+// EndHour: 0~24 inclusive
+// EndMinute: ZERO, FIFTEEN, THIRTY, FORTY_FIVE
+type AdScheduleCriterion struct {
+	Id          int64  `xml:"id,omitempty"`
+	DayOfWeek   string `xml:"dayOfWeek"`
+	StartHour   string `xml:"startHour"`
+	StartMinute string `xml:"startMinute"`
+	EndHour     string `xml:"endHour"`
+	EndMinute   string `xml:"endMinute"`
+}
+
+// AgeRangeType: AGE_RANGE_18_24, AGE_RANGE_25_34, AGE_RANGE_35_44, AGE_RANGE_45_54, AGE_RANGE_55_64, AGE_RANGE_65_UP, AGE_RANGE_UNDETERMINED, UNKNOWN
+type AgeRangeCriterion struct {
+	Id           int64  `xml:"id,omitempty"`
+	AgeRangeType string `xml:"ageRangeType"`
+}
+
+type CarrierCriterion struct {
+	Id          int64  `xml:"id,omitempty"`
+	Name        string `xml:"name,emitempty"`
+	CountryCode string `xml:"countryCode,emitempty"`
+}
+
+type ContentLabelCriterion struct {
+	Id               int64  `xml:"id,omitempty"`
+	ContentLabelType string `xml:"contentLabelType"` // ContentLabelType: "ADULTISH", "AFE", "BELOW_THE_FOLD", "CONFLICT", "DP", "EMBEDDED_VIDEO", "GAMES", "JACKASS", "PROFANITY", "UGC_FORUMS", "UGC_IMAGES", "UGC_SOCIAL", "UGC_VIDEOS", "SIRENS", "TRAGEDY", "VIDEO", "UNKNOWN"
+}
+
+type GenderCriterion struct {
+	Id         int64  `xml:"id,omitempty"`
+	GenderType string `xml:"genderType"` // GenderType:  "GENDER_MALE", "GENDER_FEMALE", "GENDER_UNDETERMINED"
+}
+
+type KeywordCriterion struct {
+	Id        int64  `xml:"https://adwords.google.com/api/adwords/cm/v201705 id,omitempty"`
+	Text      string `xml:"https://adwords.google.com/api/adwords/cm/v201705 text,omitempty"`      // Text: up to 80 characters and ten words
+	MatchType string `xml:"https://adwords.google.com/api/adwords/cm/v201705 matchType,omitempty"` // MatchType:  "EXACT", "PHRASE", "BROAD"
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.Keyword
+// Represents a keyword.
+type Keyword struct {
+	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201705 id,omitempty"`
+	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201705 type,omitempty"`
+	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201705 Criterion.Type,omitempty"`
+
+	Text      string           `xml:"https://adwords.google.com/api/adwords/cm/v201705 text,omitempty"`
+	MatchType KeywordMatchType `xml:"https://adwords.google.com/api/adwords/cm/v201705 matchType,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.KeywordMatchType
+// Match type of a keyword. i.e. the way we match a keyword string with search queries.
+// EXACT, PHRASE, BROAD
+type KeywordMatchType string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.Criterion.Type
+// The types of criteria
+type CriterionType string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.LocationTargetingStatus
+// Enum that represents the different Targeting Status values for a Location criterion.
+// ACTIVE, OBSOLETE, PHASING_OUT
+type LocationTargetingStatus string
+
+type LanguageCriterion struct {
+	Id   int64  `xml:"https://adwords.google.com/api/adwords/cm/v201705 id,omitempty"`
+	Code string `xml:"https://adwords.google.com/api/adwords/cm/v201705 code,omitempty"`
+	Name string `xml:"https://adwords.google.com/api/adwords/cm/v201705 name,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.Location
+// Represents Location criterion.  A criterion of this type can only be created using an ID.
+// LocationName:
+// DisplayType:
+// TargetingStatus: ACTIVE, OBSOLETE, PHASING_OUT
+// ParentLocations:
+type Location struct {
+	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201705 id,omitempty"`
+	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201705 type,omitempty"`
+	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201705 Criterion.Type,omitempty"`
+
+	LocationName    string                  `xml:"https://adwords.google.com/api/adwords/cm/v201705 locationName,omitempty"`
+	DisplayType     string                  `xml:"https://adwords.google.com/api/adwords/cm/v201705 displayType,omitempty"`
+	TargetingStatus LocationTargetingStatus `xml:"https://adwords.google.com/api/adwords/cm/v201705 targetingStatus,omitempty"`
+	ParentLocations []Location              `xml:"https://adwords.google.com/api/adwords/cm/v201705 parentLocations,omitempty"`
+}
+
+// MobileAppCategoryId:
+//   https://developers.google.com/adwords/api/docs/appendix/mobileappcategories
+// DisplayName:
+type MobileAppCategoryCriterion struct {
+	Id                  int64  `xml:"id,omitempty"`
+	MobileAppCategoryId int64  `xml:"mobileAppCategoryId"`
+	DisplayName         string `xml:"displayName,omitempty"`
+}
+
+// AppId: "{platform}-{platform_native_id}"
+// DisplayName:
+type MobileApplicationCriterion struct {
+	Id          int64  `xml:"id,omitempty"`
+	AppId       string `xml:"appId"`
+	DisplayName string `xml:"displayName,omitempty"`
+}
+
+// DeviceName:
+// ManufacturerName:
+// DeviceType:  DEVICE_TYPE_MOBILE, DEVICE_TYPE_TABLET
+// OperatingSystemName:
+type MobileDeviceCriterion struct {
+	Id                  int64  `xml:"id,omitempty"`
+	DeviceName          string `xml:"deviceName,omitempty"`
+	ManufacturerName    string `xml:"manufacturerName,omitempty"`
+	DeviceType          string `xml:"deviceType,omitempty"`
+	OperatingSystemName string `xml:"operatingSystemName,omitempty"`
+}
+
+// Name:
+// OsMajorVersion:
+// OsMinorVersion:
+// OperatorType: GREATER_THAN_EQUAL_TO, EQUAL_TO, UNKNOWN
+type OperatingSystemVersionCriterion struct {
+	Id             int64  `xml:"id,omitempty"`
+	Name           string `xml:"name,omitempty"`
+	OsMajorVersion int64  `xml:"osMajorVersion,omitempty"`
+	OsMinorVersion int64  `xml:"osMinorVersion,omitempty"`
+	OperatorType   string `xml:"operatorType,omitempty"`
+}
+
+// Url:
+type PlacementCriterion struct {
+	Id  int64  `xml:"id,omitempty"`
+	Url string `xml:"url"`
+}
+
+// PlatformId:
+//  Desktop	30000
+//  HighEndMobile	30001
+//  Tablet	30002
+type PlatformCriterion struct {
+	Id           int64  `xml:"id,omitempty"`
+	PlatformName string `xml:"platformName,omitempty"`
+}
+
+// Argument:
+// Operand: id, product_type, brand, adwords_grouping, condition, adwords_labels
+type ProductCondition struct {
+	Argument string `xml:"argument"`
+	Operand  string `xml:"operand"`
+}
+
+type ProductCriterion struct {
+	Id         int64              `xml:"id,omitempty"`
+	Conditions []ProductCondition `xml:"conditions"`
+	Text       string             `xml:"text,omitempty"`
+}
+
+// Represents a google_product_category level
+type ProductBiddingCategory ProductDimension
+
+type ProductBiddingCategoryData struct {
+	DimensionValue       ProductBiddingCategory `xml:"dimensionValue"`
+	ParentDimensionValue ProductBiddingCategory `xml:"parentDimensionValue"`
+	Country              string                 `xml:"country"`
+	Status               string                 `xml:"status"`
+	DisplayValue         []StringMapEntry       `xml:"displayValue"`
+}
+
+type StringMapEntry struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+type GeoPoint struct {
+	Latitude  int64 `xml:"latitudeInMicroDegrees"`
+	Longitude int64 `xml:"longitudeInMicroDegrees"`
+}
+
+type Address struct {
+	StreetAddress  string `xml:"streetAddress"`
+	StreetAddress2 string `xml:"streetAddress2"`
+	CityName       string `xml:"cityName"`
+	ProvinceCode   string `xml:"provinceCode"`
+	ProvinceName   string `xml:"provinceName"`
+	PostalCode     string `xml:"postalCode"`
+	CountryCode    string `xml:"countryCode"`
+}
+
+type ProductDimension struct {
+	Type          string `xml:"ProductDimension.Type"`
+	DimensionType string `xml:"type"`
+	Value         string `xml:"value"`
+}
+
+type ProductPartition struct {
+	Id                int64            `xml:"id,omitempty"`
+	CriteriaType      string           `xml:"type"`
+	PartitionType     string           `xml:"partitionType,omitempty"`
+	ParentCriterionId int64            `xml:"parentCriterionId,omitempty"`
+	Dimension         ProductDimension `xml:"caseValue"`
+	Cpc               *Cpc             // This value is inherited from BiddableAdgroupCriterion
+}
+
+type ProductScope struct {
+	Id           int64              `xml:"id,omitempty"`
+	CriteriaType string             `xml:"type"`
+	Dimensions   []ProductDimension `xml:"dimensions"`
+}
+
+// RadiusDistanceUnits: KILOMETERS, MILES
+// RadiusUnits:
+type ProximityCriterion struct {
+	Id                  int64    `xml:"id,omitempty"`
+	GeoPoint            GeoPoint `xml:"geoPoint"`
+	RadiusDistanceUnits string   `xml:"radiusDistanceUnits"`
+	RadiusInUnits       float64  `xml:"radiusInUnits"`
+	Address             Address  `xml:"address"`
+}
+
+type UserInterestCriterion struct {
+	Id   int64  `xml:"userInterestId,omitempty"`
+	Name string `xml:"userInterestName"`
+}
+
+type UserListCriterion struct {
+	Id                       int64  `xml:"id,omitempty"`
+	UserListId               int64  `xml:"userListId"`
+	UserListName             string `xml:"userListName"`
+	UserListMembershipStatus string `xml:"userListMembershipStatus"`
+}
+
+type VerticalCriterion struct {
+	Id       int64    `xml:"verticalId,omitempty"`
+	ParentId int64    `xml:"verticalParentId"`
+	Path     []string `xml:"path"`
+}
+
+type WebpageCondition struct {
+	Operand  string `xml:"operand"`
+	Argument string `xml:"argument"`
+}
+
+type WebpageParameter struct {
+	CriterionName string             `xml:"criterionName"`
+	Conditions    []WebpageCondition `xml:"conditions"`
+}
+
+type WebpageCriterion struct {
+	Id               int64            `xml:"id,omitempty"`
+	Parameter        WebpageParameter `xml:"parameter"`
+	CriteriaCoverage float64          `xml:"criteriaCoverage"`
+	CriteriaSamples  []string         `xml:"criteriaSamples"`
+}
+
+type Criterion interface{}
+
+func criterionUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (Criterion, error) {
+	criterionType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return nil, err
+	}
+	switch criterionType {
+	case "AdSchedule":
+		c := AdScheduleCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "AgeRange":
+		c := AgeRangeCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Carrier":
+		c := CarrierCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ContentLabel":
+		c := ContentLabelCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Gender":
+		c := GenderCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Keyword":
+		c := KeywordCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Language":
+		c := LanguageCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Location":
+		c := Location{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "MobileAppCategory":
+		c := MobileAppCategoryCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "MobileApplication":
+		c := MobileApplicationCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "MobileDevice":
+		c := MobileDeviceCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "OperatingSystemVersion":
+		c := OperatingSystemVersionCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Placement":
+		c := PlacementCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Platform":
+		c := PlatformCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Product":
+		c := ProductCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ProductPartition":
+		c := ProductPartition{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ProductScope":
+		c := ProductScope{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Proximity":
+		c := ProximityCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "CriterionUserInterest":
+		c := UserInterestCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "CriterionUserList":
+		c := UserListCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Vertical":
+		c := VerticalCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "Webpage":
+		c := WebpageCriterion{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	default:
+		return nil, fmt.Errorf("unknown criterion type %#v", criterionType)
+	}
+}
+
+func criterionMarshalXML(c Criterion, e *xml.Encoder) error {
+	criterionType := ""
+	switch t := c.(type) {
+	case AdScheduleCriterion:
+		criterionType = "AdSchedule"
+	case AgeRangeCriterion:
+		criterionType = "AgeRange"
+	case CarrierCriterion:
+		criterionType = "Carrier"
+	case ContentLabelCriterion:
+		criterionType = "ContentLabel"
+	case GenderCriterion:
+		criterionType = "Gender"
+	case KeywordCriterion:
+		criterionType = "Keyword"
+	case LanguageCriterion:
+		criterionType = "Language"
+	case Location:
+		criterionType = "Location"
+	case MobileAppCategoryCriterion:
+		criterionType = "MobileAppCategory"
+	case MobileApplicationCriterion:
+		criterionType = "MobileApplication"
+	case MobileDeviceCriterion:
+		criterionType = "MobileDevice"
+	case OperatingSystemVersionCriterion:
+		criterionType = "OperatingSystemVersion"
+	case PlacementCriterion:
+		criterionType = "Placement"
+	case PlatformCriterion:
+		criterionType = "Platform"
+	case ProductCriterion:
+		criterionType = "Product"
+	case ProximityCriterion:
+		criterionType = "Proximity"
+	case UserInterestCriterion:
+		criterionType = "CriterionUserInterest"
+	case UserListCriterion:
+		criterionType = "CriterionUserList"
+	case VerticalCriterion:
+		criterionType = "Vertical"
+	case WebpageCriterion:
+		criterionType = "Webpage"
+	default:
+		return fmt.Errorf("unknown criterion type %#v\n", t)
+	}
+	e.EncodeElement(&c, xml.StartElement{
+		xml.Name{baseUrl, "criterion"},
+		[]xml.Attr{
+			xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, criterionType},
+		},
+	})
+	return nil
+}

--- a/v201705/customer.go
+++ b/v201705/customer.go
@@ -1,0 +1,56 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type CustomerService struct {
+	Auth
+}
+
+type Customer struct {
+	CustomerId                 int64                      `xml:"customerId"`
+	CurrencyCode               string                     `xml:"currencyCode"`
+	DateTimeZone               string                     `xml:"dateTimeZone"`
+	DescriptiveName            string                     `xml:"descriptiveName"`
+	CanManageClients           bool                       `xml:"canManageClients"`
+	TestAccount                bool                       `xml:"testAccount"`
+	AutoTaggingEnabled         bool                       `xml:"autoTaggingEnabled"`
+	TrackingUrlTemplate        string                     `xml:"trackingUrlTemplate,omitempty"`
+	ConversionTrackingSettings ConversionTrackingSettings `xml:"conversionTrackingSettings"`
+	RemarketingSettings        RemarketingSettings        `xml:"remarketingSettings"`
+}
+
+type RemarketingSettings struct {
+	Snippet string `xml:"snippet"`
+}
+
+func NewCustomerService(auth *Auth) *CustomerService {
+	return &CustomerService{Auth: *auth}
+}
+
+func (s *CustomerService) GetCustomers() (customers []Customer, err error) {
+	respBody, err := s.Auth.request(
+		customerServiceUrl,
+		"getCustomers",
+		struct {
+			XMLName xml.Name
+		}{
+			XMLName: xml.Name{
+				Space: baseMcmUrl,
+				Local: "getCustomers",
+			},
+		},
+	)
+	if err != nil {
+		return customers, err
+	}
+	getResp := struct {
+		Customers []Customer `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return customers, err
+	}
+	return getResp.Customers, nil
+}

--- a/v201705/customer_feed.go
+++ b/v201705/customer_feed.go
@@ -1,0 +1,9 @@
+package v201705
+
+type CustomerFeedService struct {
+	Auth
+}
+
+func NewCustomerFeedService(auth *Auth) *CustomerFeedService {
+	return &CustomerFeedService{Auth: *auth}
+}

--- a/v201705/customer_sync.go
+++ b/v201705/customer_sync.go
@@ -1,0 +1,9 @@
+package v201705
+
+type CustomerSyncService struct {
+	Auth
+}
+
+func NewCustomerSyncService(auth *Auth) *CustomerSyncService {
+	return &CustomerSyncService{Auth: *auth}
+}

--- a/v201705/data.go
+++ b/v201705/data.go
@@ -1,0 +1,250 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type DataService struct {
+	Auth
+}
+
+func NewDataService(auth *Auth) *DataService {
+	return &DataService{Auth: *auth}
+}
+
+type LandscapePoint struct {
+	Bid                 *int64 `xml:"bid>microAmount,omitempty"`
+	Clicks              *int64 `xml:"clicks,omitempty"`
+	Cost                *int64 `xml:"cost>microAmount,omitempty"`
+	Impressions         *int64 `xml:"impressions,omitempty"`
+	PromotedImpressions *int64 `xml:"promotedImpressions,omitempty"`
+}
+
+type BidLandscape struct {
+	CampaignId      *int64           `xml:"campaignId,omitempty"`
+	AdGroupId       *int64           `xml:"adGroupId,omitempty"`
+	StartDate       *string          `xml:"startDate,omitempty"`
+	EndDate         *string          `xml:"endDate,omitempty"`
+	LandscapePoints []LandscapePoint `xml:"landscapePoints"`
+}
+
+type AdGroupBidLandscape struct {
+	BidLandscape
+	Type             string  `xml:"type"`
+	LandscapeCurrent bool    `xml:"landscapeCurrent"`
+	Errors           []error `xml:"-"`
+}
+
+type CriterionBidLandscape struct {
+	BidLandscape
+	CriterionId *int64 `xml:"criterionId,omitempty"`
+}
+
+// GetAdGroupBidLandscape returns an array of AdGroupBidLandscape objects
+// the selector.
+//
+// Example
+//
+//   adGroupBidLandscape, totalCount, err := dataService.GetAdGroupBidLandscape(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//         "Bid",
+//         "CampaignId",
+//         "LocalClicks",
+//         "LocalCost",
+//		   "LocalImpressions",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"AdGroupId", "EQUALS", []string{adGroupId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "Bid", "CampaignId", "EndDate", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions", "StartDate"
+//
+// filterable fields are
+//   "AdGroupId", "Bid", "CampaignId", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/DataService#getadgroupbidlandscape
+//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201705-DataService
+//
+func (s *DataService) GetAdGroupBidLandscape(selector Selector) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
+	// The default namespace, "", will break in 1.5 with the addition of
+	// custom namespace support.  Hence, we have to ensure that the baseUrl is
+	// set again as the proper namespace for the service/serviceSelector element
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"getAdGroupBidLandscape",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "getAdGroupBidLandscape",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+	getResp := struct {
+		Size                 int64                 `xml:"rval>totalNumEntries"`
+		AdGroupBidLandscapes []AdGroupBidLandscape `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+	return getResp.AdGroupBidLandscapes, getResp.Size, err
+}
+
+// GetCriterionBidLandscape returns an array of CriterionBidLandscape objects
+// the selector.
+//
+// Example
+//
+//   criterionBidLandscape, totalCount, err := dataService.GetCriterionBidLandscape(
+//     gads.Selector{
+//       Fields: []string{
+//         "AdGroupId",
+//		   "CriterionId",
+//         "Bid",
+//         "CampaignId",
+//         "LocalClicks",
+//         "LocalCost",
+//		   "LocalImpressions",
+//       },
+//       Predicates: []gads.Predicate{
+//         {"CriterionId", "EQUALS", []string{criterionId}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "AdGroupId", "Bid", "CampaignId", "CriterionId", "EndDate", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions", "StartDate"
+//
+// filterable fields are
+//   "AdGroupId", "Bid", "CampaignId", "CriterionId", "LandscapeCurrent", "LandscapeType", "LocalClicks",
+//   "LocalCost", "LocalImpressions", "PromotedImpressions"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/DataService#getcriterionbidlandscape
+//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201705-DataService
+//
+func (s *DataService) GetCriterionBidLandscape(selector Selector) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
+	// The default namespace, "", will break in 1.5 with the addition of
+	// custom namespace support.  Hence, we have to ensure that the baseUrl is
+	// set again as the proper namespace for the service/serviceSelector element
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"getCriterionBidLandscape",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "getCriterionBidLandscape",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+	getResp := struct {
+		Size                   int64                   `xml:"rval>totalNumEntries"`
+		CriterionBidLandscapes []CriterionBidLandscape `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+	return getResp.CriterionBidLandscapes, getResp.Size, err
+}
+
+// QueryAdGroupBidLandscape returns a slice of AdGroupBidLandscapes based on passed in AWQL query
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/DataService#queryadgroupbidlandscape
+//
+func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"queryAdGroupBidLandscape",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "queryAdGroupBidLandscape",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+
+	getResp := struct {
+		Size                 int64                 `xml:"rval>totalNumEntries"`
+		AdGroupBidLandscapes []AdGroupBidLandscape `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return adGroupBidLandscapes, totalCount, err
+	}
+	return getResp.AdGroupBidLandscapes, getResp.Size, err
+}
+
+// QueryCriterionBidLandscape returns a slice of CriterionBidLandscapes based on passed in AWQL query
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201705/DataService#querycriterionbidlandscape
+//
+func (s *DataService) QueryCriterionBidLandscape(query string) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		dataServiceUrl,
+		"queryCriterionBidLandscape",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "queryCriterionBidLandscape",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+
+	getResp := struct {
+		Size                   int64                   `xml:"rval>totalNumEntries"`
+		CriterionBidLandscapes []CriterionBidLandscape `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return criterionBidLandscapes, totalCount, err
+	}
+	return getResp.CriterionBidLandscapes, getResp.Size, err
+}

--- a/v201705/doc.go
+++ b/v201705/doc.go
@@ -1,0 +1,30 @@
+// Package gads provides a wrapper for the Google Adwords SOAP API.
+// In order to access the API you will need to sign up for an MMC
+// account[1], get a developer token[2], setup authentication[3].  The is
+// a tool in the setup_oauth2 directory that will setup a configuration
+// file.
+//
+// The package is comprised of services used to manipulate various
+// adwords structures.  To access a service you need to create an
+// gads.Auth and parse it to the service initializer, then can call
+// the service methods on the service object.
+//
+//     authConf, err := NewCredentials(context.TODO())
+//     campaignService := gads.NewCampaignService(&authConf.Auth)
+//
+//     campaigns, totalCount, err := cs.Get(
+//       gads.Selector{
+//         Fields: []string{
+//           "Id",
+//           "Name",
+//           "Status",
+//         },
+//       },
+//     )
+//
+// 1. http://www.google.com/adwords/myclientcenter/
+//
+// 2. https://developers.google.com/adwords/api/docs/signingup
+//
+// 3. https://developers.google.com/adwords/api/docs/guides/authentication
+package v201705

--- a/v201705/draft.go
+++ b/v201705/draft.go
@@ -1,0 +1,9 @@
+package v201705
+
+type DraftService struct {
+	Auth
+}
+
+func NewDraftService(auth *Auth) *DraftService {
+	return &DraftService{Auth: *auth}
+}

--- a/v201705/errors.go
+++ b/v201705/errors.go
@@ -1,0 +1,145 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type OperationError struct {
+	Code      int64  `xml:"OperationError>Code"`
+	Details   string `xml:"OperationError>Details"`
+	ErrorCode string `xml:"OperationError>ErrorCode"`
+	Message   string `xml:"OperationError>Message"`
+}
+
+type EntityError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type BudgetError struct {
+	EntityError
+}
+
+type CriterionError struct {
+	EntityError
+}
+
+type TargetError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type AdGroupServiceError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type NotEmptyError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type AdError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type LabelError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
+type UrlError struct {
+	EntityError
+}
+
+// if you exceed the quota given by google
+type RateExceededError struct {
+	RateName          string `xml:"rateName"`  // For example OperationsByMinute
+	RateScope         string `xml:"rateScope"` // ACCOUNT or DEVELOPER
+	ErrorString       string `xml:"errorString"`
+	Reason            string `xml:"reason"`
+	RetryAfterSeconds uint   `xml:"retryAfterSeconds"` // Try again in...
+}
+
+type ApiExceptionFault struct {
+	Message string        `xml:"message"`
+	Type    string        `xml:"ApplicationException.Type"`
+	Errors  []interface{} `xml:"errors"`
+}
+
+func (aes *ApiExceptionFault) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		switch start := token.(type) {
+		case xml.StartElement:
+			switch start.Name.Local {
+			case "message":
+				if err := dec.DecodeElement(&aes.Message, &start); err != nil {
+					return err
+				}
+			case "ApplicationException.Type":
+				if err := dec.DecodeElement(&aes.Type, &start); err != nil {
+					return err
+				}
+			case "errors":
+				errorType, _ := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+				switch errorType {
+				case "CriterionError", "TargetError", "BudgetError",
+					"AdGroupServiceError", "NotEmptyError", "LabelError",
+					"UrlError", "AdError", "ns2:UserListError":
+					e := EntityError{}
+					dec.DecodeElement(&e, &start)
+					aes.Errors = append(aes.Errors, e)
+				case "RateExceededError":
+					e := RateExceededError{}
+					dec.DecodeElement(&e, &start)
+					aes.Errors = append(aes.Errors, e)
+				default:
+					return fmt.Errorf("Unknown error type -> %s", start)
+				}
+			case "reason":
+				break
+			default:
+				return fmt.Errorf("Unknown error field -> %s", start)
+			}
+		}
+	}
+	return err
+}
+
+type ErrorsType struct {
+	ApiExceptionFaults []ApiExceptionFault `xml:"ApiExceptionFault"`
+}
+
+func (f ErrorsType) Error() string {
+	errors := []string{}
+	for _, e := range f.ApiExceptionFaults {
+		errors = append(errors, fmt.Sprintf("%s", e.Message))
+	}
+	return strings.Join(errors, "\n")
+}
+
+type Fault struct {
+	XMLName     xml.Name   `xml:"Fault"`
+	FaultCode   string     `xml:"faultcode"`
+	FaultString string     `xml:"faultstring"`
+	Errors      ErrorsType `xml:"detail"`
+}
+
+func (f Fault) Error() string {
+	return f.FaultString + " - " + f.Errors.Error()
+}

--- a/v201705/extension_setting.go
+++ b/v201705/extension_setting.go
@@ -1,0 +1,122 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.ExtensionSetting
+// A setting specifying when and which extensions should serve at a given level (customer, campaign, or ad group).
+type ExtensionSetting struct {
+	PlatformRestrictions ExtensionSettingPlatform `xml:"platformRestrictions,omitempty"`
+
+	Extensions Extension `xml:"https://adwords.google.com/api/adwords/cm/v201705 extensions,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.ExtensionSetting.Platform
+// Different levels of platform restrictions
+// DESKTOP, MOBILE, NONE
+type ExtensionSettingPlatform string
+
+type Extension interface{}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.ExtensionFeedItem
+// Contains base extension feed item data for an extension in an extension feed managed by AdWords.
+type ExtensionFeedItem struct {
+	XMLName xml.Name `json:"-" xml:"extensions"`
+
+	FeedId                  int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201705 feedId,omitempty"`
+	FeedItemId              int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201705 feedItemId,omitempty"`
+	Status                  *FeedItemStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201705 status,omitempty"`
+	FeedType                *FeedType                  `xml:"https://adwords.google.com/api/adwords/cm/v201705 feedType,omitempty"`
+	StartTime               string                     `xml:"https://adwords.google.com/api/adwords/cm/v201705 startTime,omitempty"` //  special value "00000101 000000" may be used to clear an existing start time.
+	EndTime                 string                     `xml:"https://adwords.google.com/api/adwords/cm/v201705 endTime,omitempty"`   //  special value "00000101 000000" may be used to clear an existing end time.
+	DevicePreference        *FeedItemDevicePreference  `xml:"https://adwords.google.com/api/adwords/cm/v201705 devicePreference,omitempty"`
+	Scheduling              *FeedItemScheduling        `xml:"https://adwords.google.com/api/adwords/cm/v201705 scheduling,omitempty"`
+	CampaignTargeting       *FeedItemCampaignTargeting `xml:"https://adwords.google.com/api/adwords/cm/v201705 campaignTargeting,omitempty"`
+	AdGroupTargeting        *FeedItemAdGroupTargeting  `xml:"https://adwords.google.com/api/adwords/cm/v201705 adGroupTargeting,omitempty"`
+	KeywordTargeting        *Keyword                   `xml:"https://adwords.google.com/api/adwords/cm/v201705 keywordTargeting,omitempty"`
+	GeoTargeting            *Location                  `xml:"https://adwords.google.com/api/adwords/cm/v201705 geoTargeting,omitempty"`
+	GeoTargetingRestriction *FeedItemGeoRestriction    `xml:"https://adwords.google.com/api/adwords/cm/v201705 geoTargetingRestriction,omitempty"`
+	PolicyData              *[]FeedItemPolicyData      `xml:"https://adwords.google.com/api/adwords/cm/v201705 policyData,omitempty"`
+
+	ExtensionFeedItemType string `xml:"https://adwords.google.com/api/adwords/cm/v201705 ExtensionFeedItem.Type,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.CallFeedItem
+// Represents a Call extension.
+type CallFeedItem struct {
+	ExtensionFeedItem
+
+	CallPhoneNumber               string             `xml:"https://adwords.google.com/api/adwords/cm/v201705 callPhoneNumber,omitempty"`
+	CallCountryCode               string             `xml:"https://adwords.google.com/api/adwords/cm/v201705 callCountryCode,omitempty"`
+	CallTracking                  bool               `xml:"https://adwords.google.com/api/adwords/cm/v201705 callTracking,omitempty"`
+	CallConversionType            CallConversionType `xml:"https://adwords.google.com/api/adwords/cm/v201705 callConversionType,omitempty"`
+	DisableCallConversionTracking bool               `xml:"https://adwords.google.com/api/adwords/cm/v201705 disableCallConversionTracking,omitempty"`
+}
+
+func extensionsUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (ext interface{}, err error) {
+	extensionsType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return
+	}
+	switch extensionsType {
+	case "CallFeedItem":
+		c := CallFeedItem{}
+		err = dec.DecodeElement(&c, &start)
+		ext = c
+	default:
+		err = fmt.Errorf("unknown Extensions type %#v", extensionsType)
+	}
+	return
+}
+
+func (s ExtensionSetting) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	e.EncodeToken(start)
+	if s.PlatformRestrictions != "NONE" {
+		e.EncodeElement(&s.PlatformRestrictions, xml.StartElement{Name: xml.Name{
+			"https://adwords.google.com/api/adwords/cm/v201705",
+			"platformRestrictions"}})
+	}
+	switch extType := s.Extensions.(type) {
+	case []CallFeedItem:
+		e.EncodeElement(s.Extensions.([]CallFeedItem), xml.StartElement{
+			xml.Name{baseUrl, "extensions"},
+			[]xml.Attr{
+				xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "CallFeedItem"},
+			},
+		})
+	default:
+		return fmt.Errorf("unknown extension type %#v\n", extType)
+
+	}
+
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (s *ExtensionSetting) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	s.Extensions = []interface{}{}
+
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			switch start.Name.Local {
+			case "platformRestrictions":
+				if err := dec.DecodeElement(&s.PlatformRestrictions, &start); err != nil {
+					return err
+				}
+			case "extensions":
+				extension, err := extensionsUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				s.Extensions = append(s.Extensions.([]interface{}), extension)
+			}
+		}
+	}
+	return nil
+}

--- a/v201705/feed.go
+++ b/v201705/feed.go
@@ -1,0 +1,87 @@
+package v201705
+
+import "encoding/xml"
+
+type FeedService struct {
+	Auth
+}
+
+func NewFeedService(auth *Auth) *FeedService {
+	return &FeedService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService
+func (s *FeedService) Query(query string) (page []Feed, totalCount int64, err error) {
+	respBody, err := s.Auth.request(
+		feedServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	getResp := struct {
+		Size  int64  `xml:"rval>totalNumEntries"`
+		Feeds []Feed `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return
+	}
+	return getResp.Feeds, getResp.Size, err
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.Feed.Type
+// Feed hard type. Values coincide with placeholder type id.
+// Enum: NONE, SITELINK, CALL, APP, REVIEW, AD_CUSTOMIZER, CALLOUT, STRUCTURED_SNIPPET, PRICE
+type FeedType string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService.Feed.Status
+// Status of the Feed.
+// ENABLED, REMOVED, UNKNOWN
+type FeedStatus string
+
+// Used to Specify who manages the FeedAttributes for the Feed.
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService.Feed.Origin
+// USER, ADWORDS, UNKNOWN
+type FeedOrigin string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService.FeedAttribute.Type
+// Possible data types.
+type FeedAttributeType string
+
+// Configuration data allowing feed items to be populated for a system feed.
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService.SystemFeedGenerationData
+type SystemFeedGenerationData struct {
+	SystemFeedGenerationDataType string `xml:"https://adwords.google.com/api/adwords/cm/v201705 SystemFeedGenerationData.Type,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService.FeedAttribute
+// FeedAttributes define the types of data expected to be present in a Feed.
+// A single FeedAttribute specifies the expected type of the FeedItemAttributes with the same FeedAttributeId.
+// Optionally, a FeedAttribute can be marked as being part of a FeedItem's unique key.
+type FeedAttribute struct {
+	Id          int64             `xml:"https://adwords.google.com/api/adwords/cm/v201705 id,omitempty"`
+	Name        string            `xml:"https://adwords.google.com/api/adwords/cm/v201705 name,omitempty"`
+	Type        FeedAttributeType `xml:"https://adwords.google.com/api/adwords/cm/v201705 type,omitempty"`
+	IsPartOfKey bool              `xml:"https://adwords.google.com/api/adwords/cm/v201705 isPartOfKey,omitempty"`
+}
+
+// A Feed identifies a source of data and its schema.
+// The data for the Feed can either be user-entered via the FeedItemService or system-generated, in which case the data is provided automatically.
+// https://developers.google.com/adwords/api/docs/reference/v201705/FeedService.Feed
+type Feed struct {
+	Id                       int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201705 id,omitempty"`
+	Name                     string                     `xml:"https://adwords.google.com/api/adwords/cm/v201705 name,omitempty"`
+	Attributes               []FeedAttribute            `xml:"https://adwords.google.com/api/adwords/cm/v201705 attributes,omitempty"`
+	Status                   FeedStatus                 `xml:"https://adwords.google.com/api/adwords/cm/v201705 status,omitempty"`
+	Origin                   FeedOrigin                 `xml:"https://adwords.google.com/api/adwords/cm/v201705 origin,omitempty"`
+	SystemFeedGenerationData []SystemFeedGenerationData `xml:"https://adwords.google.com/api/adwords/cm/v201705 systemFeedGenerationData,omitempty"`
+}

--- a/v201705/feed_item.go
+++ b/v201705/feed_item.go
@@ -1,0 +1,104 @@
+package v201705
+
+type FeedItemService struct {
+	Auth
+}
+
+func NewFeedItemService(auth *Auth) *FeedItemService {
+	return &FeedItemService{Auth: *auth}
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItem.Status
+// ENABLED, REMOVED, UNKNOWN
+type FeedItemStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemDevicePreference
+// Represents a FeedItem device preference
+type FeedItemDevicePreference struct {
+	DevicePreference int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 devicePreference,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemScheduling
+// Represents a collection of FeedItem schedules specifying all time intervals for which the feed item may serve.
+// Any time range not covered by the specified FeedItemSchedules will prevent the feed item from serving during those times.
+type FeedItemScheduling struct {
+	feedItemSchedules int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 feedItemSchedules,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemSchedule
+// Represents a FeedItem schedule, which specifies a time interval on a given day when the feed item may serve.
+// The FeedItemSchedule times are in the account's time zone.
+type FeedItemSchedule struct {
+	DayOfWeek   DayOfWeek    `xml:"https://adwords.google.com/api/adwords/cm/v201705 dayOfWeek,omitempty"`
+	StartHour   int          `xml:"https://adwords.google.com/api/adwords/cm/v201705 startHour,omitempty"`
+	StartMinute MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201705 startMinute,omitempty"`
+	EndHour     int          `xml:"https://adwords.google.com/api/adwords/cm/v201705 endHour,omitempty"`
+	EndMinute   MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201705 endMinute,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemCampaignTargeting
+// Specifies the campaign the request context must match in order for the feed item to be considered eligible for serving (aka the targeted campaign).
+// E.g., if the below campaign targeting is set to campaignId = X, then the feed item can only serve under campaign X.
+type FeedItemCampaignTargeting struct {
+	TargetingCampaignId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 TargetingCampaignId,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemAdGroupTargeting
+// Specifies the adgroup the request context must match in order for the feed item to be considered eligible for serving (aka the targeted adgroup).
+// E.g., if the below adgroup targeting is set to adgroup = X, then the feed item can only serve under adgroup X.
+type FeedItemAdGroupTargeting struct {
+	TargetingAdGroupId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 TargetingAdGroupId,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemGeoRestriction
+// Represents a FeedItem geo restriction.
+type FeedItemGeoRestriction struct {
+	GeoRestriction GeoRestriction `xml:"https://adwords.google.com/api/adwords/cm/v201705 geoRestriction,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemPolicyData
+// Contains offline-validation and approval results for a given FeedItem and FeedMapping.
+// Each validation data indicates any issues found on the feed item when used in the context of the feed mapping.
+type FeedItemPolicyData struct {
+	PolicyData
+	PlaceholderType           int                               `xml:"https://adwords.google.com/api/adwords/cm/v201705 placeholderType,omitempty"`
+	FeedMappingId             int64                             `xml:"https://adwords.google.com/api/adwords/cm/v201705 feedMappingId,omitempty"`
+	ValidationStatus          FeedItemValidationStatus          `xml:"https://adwords.google.com/api/adwords/cm/v201705 validationStatus,omitempty"`
+	ApprovalStatus            FeedItemApprovalStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201705 approvalStatus,omitempty"`
+	ValidationErrors          []FeedItemAttributeError          `xml:"https://adwords.google.com/api/adwords/cm/v201705 validationErrors,omitempty"`
+	QualityApprovalStatus     FeedItemQualityApprovalStatus     `xml:"https://adwords.google.com/api/adwords/cm/v201705 qualityApprovalStatus,omitempty"`
+	QualityDisapprovalReasons FeedItemQualityDisapprovalReasons `xml:"https://adwords.google.com/api/adwords/cm/v201705 qualityDisapprovalReasons,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemValidationStatus
+// Validation status of a FeedItem
+// UNCHECKED, ERROR, VALID
+type FeedItemValidationStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemApprovalStatus
+// Feed item approval status
+// UNCHECKED, APPROVED, DISAPPROVED
+type FeedItemApprovalStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemAttributeError
+// Contains validation error details for a set of feed attributes
+type FeedItemAttributeError struct {
+	FeedAttributeIds    []int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 feedAttributeIds,omitempty"`
+	ValidationErrorCode int     `xml:"https://adwords.google.com/api/adwords/cm/v201705 validationErrorCode,omitempty"`
+	ErrorInformation    string  `xml:"https://adwords.google.com/api/adwords/cm/v201705 errorInformation,omitempty"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemQualityApprovalStatus
+// Feed item quality evaluation approval status
+// UNCHECKED, APPROVED, DISAPPROVED
+type FeedItemQualityApprovalStatus string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.FeedItemQualityDisapprovalReasons
+// Feed item quality evaluation disapproval reasons.
+type FeedItemQualityDisapprovalReasons string
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.CallConversionType
+// Conversion type for a call extension.
+type CallConversionType struct {
+	ConversionTypeId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201705 conversionTypeId,omitempty"`
+}

--- a/v201705/feed_mapping.go
+++ b/v201705/feed_mapping.go
@@ -1,0 +1,9 @@
+package v201705
+
+type FeedMappingService struct {
+	Auth
+}
+
+func NewFeedMappingService(auth *Auth) *FeedMappingService {
+	return &FeedMappingService{Auth: *auth}
+}

--- a/v201705/label.go
+++ b/v201705/label.go
@@ -1,0 +1,187 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type LabelService struct {
+	Auth
+}
+
+func NewLabelService(auth *Auth) *LabelService {
+	return &LabelService{Auth: *auth}
+}
+
+// Label represents a label.
+type Label struct {
+	Type   string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Id     int64  `xml:"id,omitempty"`
+	Name   string `xml:"name,omitempty"`
+	Status string `xml:"status,omitempty"`
+}
+
+// NewTextLabel returns an new Label struct for creating a new TextLabel.
+func NewTextLabel(name string) Label {
+	return Label{
+		Type: "TextLabel",
+		Name: name,
+	}
+}
+
+// LabelOperations is a map of operations to perform on Label's
+type LabelOperations map[string][]Label
+
+// Get returns an array of Label's and the total number of Label's matching
+// the selector.
+//
+// Example
+//
+//   labels, totalCount, err := labelService.Get(
+//     Selector{
+//       Fields: []string{"LabelId","LabelName","LabelStatus"},
+//       Predicates: []Predicate{
+//         {"LabelStatus", "EQUALS", []string{"ENABLED"}},
+//       },
+//     },
+//   )
+//
+// Selectable fields are
+//   "LabelId", "LabelName", "LabelStatus"
+//
+// filterable fields are
+//   "LabelId", "LabelName", "LabelStatus"
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/LabelService#get
+//
+func (s LabelService) Get(selector Selector) (labels []Label, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		labelServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return labels, totalCount, err
+	}
+	getResp := struct {
+		Size   int64   `xml:"rval>totalNumEntries"`
+		Labels []Label `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return labels, totalCount, err
+	}
+	return getResp.Labels, getResp.Size, err
+}
+
+// Mutate allows you to add, modify and remove labels, returning the
+// modified labels.
+//
+// Example
+//
+//  labels, err := labelService.Mutate(
+//    LabelOperations{
+//      "ADD": {
+//        NewTextLabel("Label1"),
+//        NewTextLabel("Label2"),
+//      },
+//      "SET": {
+//        modifiedLabel,
+//      },
+//      "REMOVE": {
+//        Label{Type:"TextLabel",Id:10},
+//      },
+//    },
+//  )
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201409/LabelService#mutate
+//
+func (s *LabelService) Mutate(labelOperations LabelOperations) (labels []Label, err error) {
+	type labelOperation struct {
+		Action string `xml:"operator"`
+		Label  Label  `xml:"operand"`
+	}
+	operations := []labelOperation{}
+	for action, labels := range labelOperations {
+		for _, label := range labels {
+			operations = append(operations,
+				labelOperation{
+					Action: action,
+					Label:  label,
+				},
+			)
+		}
+	}
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []labelOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+	respBody, err := s.Auth.request(labelServiceUrl, "mutate", mutation)
+	if err != nil {
+		return labels, err
+	}
+	mutateResp := struct {
+		Labels []Label `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return labels, err
+	}
+	return mutateResp.Labels, err
+}
+
+// Query is not yet implemented
+//
+// Relevant documentation
+//
+//     https://developers.google.com/adwords/api/docs/reference/v201506/LabelService#query
+//
+func (s *LabelService) Query(query string) (labels []Label, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		labelServiceUrl,
+		"query",
+		AWQLQuery{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "query",
+			},
+			Query: query,
+		},
+	)
+
+	if err != nil {
+		return labels, totalCount, err
+	}
+
+	getResp := struct {
+		Size   int64   `xml:"rval>totalNumEntries"`
+		Labels []Label `xml:"rval>entries"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return labels, totalCount, err
+	}
+	return getResp.Labels, getResp.Size, err
+
+}

--- a/v201705/label_test.go
+++ b/v201705/label_test.go
@@ -1,0 +1,83 @@
+package v201705
+
+import (
+	"testing"
+)
+
+func testLabelService(t *testing.T) (service *LabelService) {
+	return &LabelService{Auth: testAuthSetup(t)}
+}
+
+func testLabel(t *testing.T) (Label, func()) {
+	s := testLabelService(t)
+	labels, err := s.Mutate(
+		LabelOperations{
+			"ADD": {
+				NewTextLabel("Label_" + rand_str(10)),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupLabel := func() {
+		_, err = s.Mutate(LabelOperations{"REMOVE": labels})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	return labels[0], cleanupLabel
+}
+
+func TestLabel(t *testing.T) {
+	ls := testLabelService(t)
+	labels, err := ls.Mutate(
+		LabelOperations{
+			"ADD": {
+				NewTextLabel("Label" + rand_str(10)),
+				NewTextLabel("Label" + rand_str(10)),
+				NewTextLabel("Label" + rand_str(10)),
+				NewTextLabel("Label" + rand_str(10)),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundLabels, _, err := ls.Get(
+		Selector{
+			Fields: []string{
+				"LabelId",
+				"LabelName",
+				"LabelStatus",
+			},
+			Predicates: []Predicate{
+				{"LabelStatus", "EQUALS", []string{"ENABLED"}},
+			},
+			Ordering: []OrderBy{
+				{"LabelId", "ASCENDING"},
+			},
+			Paging: &Paging{
+				Offset: 0,
+				Limit:  500,
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("found %d labels\n", len(foundLabels))
+	for _, c := range labels {
+		func(label Label) {
+			for _, foundLabel := range foundLabels {
+				if foundLabel.Id == label.Id {
+					return
+				}
+			}
+			t.Errorf("label %d not found in \n%#v\n", label.Id, foundLabels)
+		}(c)
+	}
+}

--- a/v201705/location_criterion.go
+++ b/v201705/location_criterion.go
@@ -1,0 +1,52 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type LocationCriterionService struct {
+	Auth
+}
+
+func NewLocationCriterionService(auth *Auth) *LocationCriterionService {
+	return &LocationCriterionService{Auth: *auth}
+}
+
+type LocationCriterion struct {
+	Location      Location `xml:"location"`
+	CanonicalName string   `xml:"canonicalName,omitempty"`
+	Reach         string   `xml:"reach,omitempty"`
+	Locale        string   `xml:"locale,omitempty"`
+	SearchTerm    string   `xml:"searchTerm"`
+}
+
+type LocationCriterions []LocationCriterion
+
+func (s *LocationCriterionService) Get(selector Selector) (locationCriterions LocationCriterions, err error) {
+	selector.XMLName = xml.Name{baseUrl, "selector"}
+	respBody, err := s.Auth.request(
+		locationCriterionServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return locationCriterions, err
+	}
+	getResp := struct {
+		LocationCriterions LocationCriterions `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return locationCriterions, err
+	}
+	return getResp.LocationCriterions, err
+}

--- a/v201705/location_criterion_test.go
+++ b/v201705/location_criterion_test.go
@@ -1,0 +1,39 @@
+package v201705
+
+import (
+	"fmt"
+	"testing"
+	//  "encoding/xml"
+)
+
+func testLocationCriterionService(t *testing.T) (service *LocationCriterionService) {
+	return &LocationCriterionService{Auth: testAuthSetup(t)}
+}
+
+func TestLocationCriterion(t *testing.T) {
+	lcs := testLocationCriterionService(t)
+	locationCriterions, err := lcs.Get(
+		Selector{
+			Fields: []string{
+				"Id",
+				"LocationName",
+				"CanonicalName",
+				"DisplayType",
+				"ParentLocations",
+				"Reach",
+				"TargetingStatus",
+			},
+			Predicates: []Predicate{
+				{"LocationName", "IN", []string{"Cameroon", "India", "Iraq", "Nigeria", "Pakistan", "Philippines"}},
+				{"Locale", "EQUALS", []string{"en"}},
+			},
+		},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	for _, locationCriterion := range locationCriterions {
+		location := locationCriterion.Location
+		fmt.Printf("%d. %s, %s\n", location.Id, location.LocationName, location.DisplayType)
+	}
+}

--- a/v201705/managed_customer.go
+++ b/v201705/managed_customer.go
@@ -1,0 +1,117 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type ManagedCustomer struct {
+	Name                  string         `xml:"name"`
+	CustomerId            int64          `xml:"customerId,omitempty"`
+	CanManageClients      bool           `xml:"canManageClients,omitempty"`
+	CurrencyCode          string         `xml:"currencyCode"`
+	DateTimeZone          string         `xml:"dateTimeZone"`
+	TestAccount           bool           `xml:"testAccount,omitempty"`
+	AccountLabels         []AccountLabel `xml:"accountLabels,omitempty"`
+	ExcludeHiddenAccounts bool           `xml:"excludeHiddenAccounts,omitempty"`
+}
+
+type ManagedCustomerLink struct {
+	ManagerCustomerId      int64  `xml:"managerCustomerId"`
+	ClientCustomerId       int64  `xml:"clientCustomerId"`
+	LinkStatus             string `xml:"linkStatus"`
+	PendingDescriptiveName string `xml:"pendingDescriptiveName"`
+	IsHidden               bool   `xml:isHidden"`
+}
+
+type ManagedCustomerOperations map[string][]ManagedCustomer
+
+type ManagedCustomerPage struct {
+	Size                 int64                 `xml:"rval>totalNumEntries"`
+	ManagedCustomers     []ManagedCustomer     `xml:"rval>entries"`
+	ManagedCustomerLinks []ManagedCustomerLink `xml:"rval>links"`
+}
+
+type AccountLabel struct {
+	Id   int64  `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type ManagedCustomerService struct {
+	Auth
+}
+
+func NewManagedCustomerService(auth *Auth) *ManagedCustomerService {
+	return &ManagedCustomerService{Auth: *auth}
+}
+
+func (s *ManagedCustomerService) Get(selector Selector) (managedCustomerPage ManagedCustomerPage, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseMcmUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		managedCustomerServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseMcmUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return managedCustomerPage, totalCount, err
+	}
+	getResp := ManagedCustomerPage{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return managedCustomerPage, totalCount, err
+	}
+	return getResp, totalCount, nil
+}
+
+func (s *ManagedCustomerService) Mutate(managedCustomerOperations ManagedCustomerOperations) (managedCustomers []ManagedCustomer, err error) {
+	type managedCustomerOperation struct {
+		Action          string          `xml:"https://adwords.google.com/api/adwords/cm/v201705 operator"`
+		ManagedCustomer ManagedCustomer `xml:"operand"`
+	}
+
+	operations := []managedCustomerOperation{}
+	for action, managedCustomers := range managedCustomerOperations {
+		for _, managedCustomer := range managedCustomers {
+			operations = append(operations,
+				managedCustomerOperation{
+					Action:          action,
+					ManagedCustomer: managedCustomer,
+				},
+			)
+		}
+	}
+
+	mutation := struct {
+		XMLName xml.Name
+		Ops     []managedCustomerOperation `xml:"operations"`
+	}{
+		XMLName: xml.Name{
+			Space: baseMcmUrl,
+			Local: "mutate",
+		},
+		Ops: operations,
+	}
+
+	respBody, err := s.Auth.request(managedCustomerServiceUrl, "mutate", mutation)
+	if err != nil {
+		return managedCustomers, err
+	}
+
+	mutateResp := struct {
+		ManagedCustomers []ManagedCustomer `xml:"rval>value"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &mutateResp)
+	if err != nil {
+		return managedCustomers, err
+	}
+
+	return mutateResp.ManagedCustomers, err
+}

--- a/v201705/media.go
+++ b/v201705/media.go
@@ -1,0 +1,133 @@
+package v201705
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+)
+
+type MediaService struct {
+	Auth
+}
+
+func NewMediaService(auth *Auth) *MediaService {
+	return &MediaService{Auth: *auth}
+}
+
+type Dimensions struct {
+	Name   string `xml:"key"` // "FULL", "SHRUNKEN", "PREVIEW", "VIDEO_THUMBNAIL"
+	Width  int64  `xml:"value>width"`
+	Height int64  `xml:"value>height"`
+}
+
+type ImageUrl struct {
+}
+
+// Media represents an audio, image or video file.
+type Media struct {
+	Type         string       `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Id           int64        `xml:"mediaId,omitempty"`
+	MediaType    string       `xml:"type"` // "AUDIO", "DYNAMIC_IMAGE", "ICON", "IMAGE", "STANDARD_ICON", "VIDEO"
+	ReferenceId  int64        `xml:"referenceId,omitempty"`
+	Dimensions   []Dimensions `xml:"dimensions"`
+	Urls         []ImageUrl   `xml:"urls"`
+	MimeType     string       `xml:"mimeType,omitempty"` // "IMAGE_JPEG", "IMAGE_GIF", "IMAGE_PNG", "FLASH", "TEXT_HTML", "PDF", "MSWORD", "MSEXCEL", "RTF", "AUDIO_WAV", "AUDIO_MP3"
+	SourceUrl    string       `xml:"sourceUrl,omitempty"`
+	Name         string       `xml:"name"`
+	FileSize     int64        `xml:"fileSize,omitempty"`   // File size in bytes
+	CreationTime string       `xml:"createTime,omitempty"` // format is YYYY-MM-DD HH:MM:SS+TZ
+
+	// Audio / Video
+	DurationMillis   int64  `xml:"durationMillis,omitempty"`
+	StreamingUrl     string `xml:"streamingUrl,omitempty"`
+	ReadyToPlayOnWeb bool   `xml:"readyToPlayOnTheWeb,omitempty"`
+
+	// Image
+	Data string `xml:"data,omitempty"` // base64Binary encoded raw image data
+
+	// Video
+	IndustryStandardCommercialIdentifier string `xml:"industryStandardCommercialIdentifier,omitempty"`
+	AdvertisingId                        string `xml:"advertisingId,omitempty"`
+	YouTubeVideoIdString                 string `xml:"youTubeVideoIdString,omitempty"`
+}
+
+func NewAudio(name, mediaType, mimeType string) (image Media) {
+	return Media{
+		Name: name,
+		Type: "Audio",
+	}
+}
+
+func NewImage(name, mediaType, mimeType string, data []byte) (image Media) {
+	imageData := base64.StdEncoding.EncodeToString(data)
+	return Media{
+		Name:      name,
+		Type:      "Image",
+		MediaType: mediaType,
+		Data:      imageData,
+	}
+}
+
+func NewVideo(mediaType string) (image Media) {
+	return Media{
+		Type: "Video",
+	}
+}
+
+func (s *MediaService) Get(selector Selector) (medias []Media, totalCount int64, err error) {
+	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
+	respBody, err := s.Auth.request(
+		mediaServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     Selector
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return medias, totalCount, err
+	}
+	getResp := struct {
+		Size   int64   `xml:"rval>totalNumEntries"`
+		Medias []Media `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return medias, totalCount, err
+	}
+	return getResp.Medias, getResp.Size, err
+}
+
+func (s *MediaService) Query(query string) (medias []Media, totalCount int64, err error) {
+	return medias, totalCount, ERROR_NOT_YET_IMPLEMENTED
+}
+
+func (s *MediaService) Upload(medias []Media) (uploadedMedias []Media, err error) {
+	upload := struct {
+		XMLName xml.Name
+		Medias  []Media `xml:"media"`
+	}{
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "upload",
+		},
+		Medias: medias,
+	}
+	respBody, err := s.Auth.request(mediaServiceUrl, "upload", upload)
+	if err != nil {
+		return uploadedMedias, err
+	}
+	uploadResp := struct {
+		Medias []Media `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &uploadResp)
+	if err != nil {
+		return uploadedMedias, err
+	}
+	return uploadResp.Medias, err
+}

--- a/v201705/media_test.go
+++ b/v201705/media_test.go
@@ -1,0 +1,78 @@
+package v201705
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func testMediaService(t *testing.T) (service *MediaService) {
+	return &MediaService{Auth: testAuthSetup(t)}
+}
+
+func TestMedia(t *testing.T) {
+
+	// load image into []byte
+	imageUrl := "http://www.google.com/intl/en/adwords/select/images/samples/inline.jpg"
+	resp, err := http.Get(imageUrl)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	ms := testMediaService(t)
+	images, err := ms.Upload(
+		[]Media{
+			NewImage("image1", "IMAGE", "IMAGE_JPEG", body),
+			NewImage("image2", "IMAGE", "IMAGE_JPEG", body),
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v", images)
+
+	var pageSize int64 = 500
+	var offset int64 = 0
+	paging := Paging{
+		Offset: offset,
+		Limit:  pageSize,
+	}
+	for {
+		medias, totalCount, err := ms.Get(
+			Selector{
+				Fields: []string{
+					"MediaId",
+					"Height",
+					"Width",
+					"MimeType",
+					"Urls",
+				},
+				Predicates: []Predicate{
+					{"Type", "IN", []string{"IMAGE", "VIDEO"}},
+				},
+				Paging: &paging,
+			},
+		)
+		if err != nil {
+			fmt.Printf("Error occured finding medias")
+		}
+		for _, m := range medias {
+			for _, d := range m.Dimensions {
+				if d.Name == "FULL" {
+					fmt.Printf("Entry ID %d with dimensions %dx%d and MIME type is '%s'\n", m.Id, d.Height, d.Width, m.MimeType)
+				}
+			}
+		}
+		// Increment values to request the next page.
+		offset += pageSize
+		paging.Offset = offset
+		if totalCount < offset {
+			fmt.Printf("\tFound %d entries.", totalCount)
+			break
+		}
+	}
+
+}

--- a/v201705/misc_test.go
+++ b/v201705/misc_test.go
@@ -1,0 +1,29 @@
+package v201705
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"io/ioutil"
+	"net/http"
+)
+
+func ExampleMediaService_Upload() {
+	// load image into []byte
+	imageUrl := "http://www.google.com/intl/en/adwords/select/images/samples/inline.jpg"
+	resp, err := http.Get(imageUrl)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	// load credentials from
+	authConf, _ := NewCredentials(context.TODO())
+	ms := NewMediaService(&authConf.Auth)
+
+	images, err := ms.Upload([]Media{NewImage("image1", "IMAGE", "IMAGE_JPEG", body)})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v", images)
+}

--- a/v201705/negative_ad_group_criterion.go
+++ b/v201705/negative_ad_group_criterion.go
@@ -1,0 +1,60 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type NegativeAdGroupCriterion struct {
+	AdGroupId    int64     `xml:"adGroupId"`
+	CriterionUse string    `xml:"criterionUse"`
+	Criterion    Criterion `xml:"criterion"`
+}
+
+func (nagc NegativeAdGroupCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Attr = append(
+		start.Attr,
+		xml.Attr{
+			xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"},
+			"NegativeAdGroupCriterion",
+		},
+	)
+	e.EncodeToken(start)
+	e.EncodeElement(&nagc.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+	criterionMarshalXML(nagc.Criterion, e)
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (nagc *NegativeAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "adGroupId":
+				if err := dec.DecodeElement(&nagc.AdGroupId, &start); err != nil {
+					return err
+				}
+			case "criterionUse":
+				if err := dec.DecodeElement(&nagc.CriterionUse, &start); err != nil {
+					return err
+				}
+			case "criterion":
+				criterion, err := criterionUnmarshalXML(dec, start)
+				if err != nil {
+					return err
+				}
+				nagc.Criterion = criterion
+			case "AdGroupCriterion.Type":
+				break
+			default:
+				return fmt.Errorf("unknown NegativeAdGroupCriterion field %s", tag)
+			}
+		}
+	}
+	return nil
+}

--- a/v201705/oauth2.go
+++ b/v201705/oauth2.go
@@ -1,0 +1,109 @@
+package v201705
+
+import (
+	"encoding/json"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"time"
+)
+
+type AuthConfig struct {
+	file         string             `json:"-"`
+	OAuth2Config *oauth2.Config     `json:"oauth2.Config"`
+	OAuth2Token  *oauth2.Token      `json:"oauth2.Token"`
+	tokenSource  oauth2.TokenSource `json:"-"`
+	Auth         Auth               `json:"gads.Auth"`
+}
+
+type OAuthConfigArgs struct {
+	ClientID     string
+	ClientSecret string
+}
+
+type OAuthTokenArgs struct {
+	AccessToken  string
+	RefreshToken string
+}
+
+type Credentials struct {
+	Config OAuthConfigArgs
+	Token  OAuthTokenArgs
+	Auth   Auth
+}
+
+func NewCredentialsFromFile(pathToFile string) (ac AuthConfig, err error) {
+	ctx := context.TODO()
+	data, err := ioutil.ReadFile(pathToFile)
+	if err != nil {
+		return ac, err
+	}
+	if err := json.Unmarshal(data, &ac); err != nil {
+		return ac, err
+	}
+	ac.file = pathToFile
+	ac.tokenSource = ac.OAuth2Config.TokenSource(ctx, ac.OAuth2Token)
+	ac.Auth.Client = ac.OAuth2Config.Client(ctx, ac.OAuth2Token)
+	return ac, err
+}
+
+func NewCredentialsFromParams(creds Credentials) (config AuthConfig, err error) {
+	var gcfg AuthConfig
+
+	expiresAt, _ := time.Parse(time.RFC3339, "2015-07-28T14:51:53.543430418-04:00")
+
+	// Create a token
+	gcfg.OAuth2Token = &oauth2.Token{
+		AccessToken:  creds.Token.AccessToken,
+		TokenType:    "Bearer",
+		RefreshToken: creds.Token.RefreshToken,
+		Expiry:       expiresAt,
+	}
+	ctx := context.TODO()
+
+	gcfg.OAuth2Config = &oauth2.Config{
+		ClientID:     creds.Config.ClientID,
+		ClientSecret: creds.Config.ClientSecret,
+		Scopes: []string{
+			"https://adwords.google.com/api/adwords",
+		},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+			TokenURL: "https://accounts.google.com/o/oauth2/token",
+		},
+	}
+
+	gcfg.Auth = Auth{
+		CustomerId:     creds.Auth.CustomerId,
+		DeveloperToken: creds.Auth.DeveloperToken,
+		Client:         gcfg.OAuth2Config.Client(ctx, gcfg.OAuth2Token),
+	}
+
+	return gcfg, nil
+}
+
+// Save writes the contents of AuthConfig back to the JSON file it was
+// loaded from.
+func (c AuthConfig) Save() error {
+	configData, err := json.MarshalIndent(&c, "", "    ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(c.file, configData, 0600)
+}
+
+// Token implements oauth2.TokenSource interface and store updates to
+// config file.
+func (c AuthConfig) Token() (token *oauth2.Token, err error) {
+	// use cached token
+	if c.OAuth2Token.Valid() {
+		return c.OAuth2Token, err
+	}
+
+	// get new token from tokens source and store
+	c.OAuth2Token, err = c.tokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	return token, c.Save()
+}

--- a/v201705/offline_conversion_feed.go
+++ b/v201705/offline_conversion_feed.go
@@ -1,0 +1,9 @@
+package v201705
+
+type OfflineConversionService struct {
+	Auth
+}
+
+func NewOfflineConversionService(auth *Auth) *OfflineConversionService {
+	return &OfflineConversionService{Auth: *auth}
+}

--- a/v201705/page.go
+++ b/v201705/page.go
@@ -1,0 +1,8 @@
+package v201705
+
+// https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupExtensionSettingService.Page
+// Contains the results from a get call.
+type Page struct {
+	TotalNumEntries int    `xml:"https://adwords.google.com/api/adwords/cm/v201705 totalNumEntries,omitempty"`
+	PageType        string `xml:"https://adwords.google.com/api/adwords/cm/v201705 Page.Type,omitempty"`
+}

--- a/v201705/report_definition.go
+++ b/v201705/report_definition.go
@@ -1,0 +1,73 @@
+package v201705
+
+import (
+	"encoding/xml"
+)
+
+type ReportDefinition struct {
+	Selector       Selector `xml:"selector"`
+	ReportName     string   `xml:"reportName"`
+	ReportType     string   `xml:"reportType"`
+	DateRangeType  string   `xml:"dateRangeType"`
+	DownloadFormat string   `xml:"downloadFormat"`
+}
+
+type ReportDefinitionField struct {
+	FieldName           string          `xml:"fieldName"`
+	DisplayFieldName    string          `xml:"displayFieldName"`
+	XmlAttributeName    string          `xml:"xmlAttributeName"`
+	FieldType           string          `xml:"fieldType"`
+	FieldBehavior       string          `xml:"fieldBehavior"`
+	EnumValues          []string        `xml:"enumValues"`
+	CanSelect           bool            `xml:"canSelect"`
+	CanFilter           bool            `xml:"canFilter"`
+	IsEnumType          bool            `xml:"isEnumType"`
+	IsBeta              bool            `xml:"isBeta"`
+	IsZeroRowCompatible bool            `xml:"isZeroRowCompatible"`
+	EnumValuePairs      []EnumValuePair `xml:"enumValuePairs"`
+}
+
+type EnumValuePair struct {
+	EnumValue        string `xml:"enumValue"`
+	EnumDisplayValue string `xml:"enumDisplayvalue"`
+}
+
+type ReportDefinitionService struct {
+	Auth
+}
+
+type ReportDefinitionRequest struct {
+	ReportType string `xml:"reportType"`
+}
+
+func NewReportDefinitionService(auth *Auth) *ReportDefinitionService {
+	return &ReportDefinitionService{Auth: *auth}
+}
+
+func (s *ReportDefinitionService) GetReportFields(report string) (fields []ReportDefinitionField, err error) {
+	respBody, err := s.Auth.request(
+		reportDefinitionServiceUrl,
+		"get",
+		struct {
+			XMLName    xml.Name
+			ReportType string `xml:"reportType"`
+		}{
+			XMLName: xml.Name{
+				Space: baseUrl,
+				Local: "getReportFields",
+			},
+			ReportType: report,
+		},
+	)
+	if err != nil {
+		return fields, err
+	}
+	getResp := struct {
+		Fields []ReportDefinitionField `xml:"rval"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return fields, err
+	}
+	return getResp.Fields, err
+}

--- a/v201705/report_download.go
+++ b/v201705/report_download.go
@@ -1,0 +1,117 @@
+package v201705
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/xml"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type ReportDownloadService struct {
+	Auth
+}
+
+type reportDefinitionXml struct {
+	*ReportDefinition
+	XMLName xml.Name
+}
+
+func NewReportDownloadService(auth *Auth) *ReportDownloadService {
+	return &ReportDownloadService{Auth: *auth}
+}
+
+func (s *ReportDownloadService) Get(reportDefinition ReportDefinition) (res interface{}, err error) {
+	reportDefinition.Selector.XMLName = xml.Name{baseUrl, "selector"}
+	repDef := reportDefinitionXml{
+		ReportDefinition: &reportDefinition,
+		XMLName: xml.Name{
+			Space: baseUrl,
+			Local: "reportDefinition",
+		},
+	}
+	body, err := xml.MarshalIndent(repDef, "  ", "  ")
+	if err != nil {
+		return res, err
+	}
+	form := url.Values{}
+	form.Add("__rdxml", string(body))
+	resp, err := s.makeRequest(form)
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+	/*respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return res, err
+	}
+	return string(respBody), err*/
+	return parseReport(resp.Body)
+}
+
+func (s *ReportDownloadService) AWQL(awql string, fmt string) (res interface{}, err error) {
+	form := url.Values{}
+	form.Add("__rdquery", awql)
+	form.Add("__fmt", fmt)
+	resp, err := s.makeRequest(form)
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+	/*respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return res, err
+	}
+	return string(respBody), err*/
+
+	// if we didn't get a 200 bubble up the error
+	if resp.StatusCode != 200 {
+		response, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return res, err
+		}
+		return res, errors.New(string(response))
+	}
+
+	return parseReport(resp.Body)
+}
+
+// Make our http request using the given form (re-usable for either XML or AWQL)
+func (s *ReportDownloadService) makeRequest(form url.Values) (res *http.Response, err error) {
+	req, err := http.NewRequest("POST", reportDownloadServiceUrl.Url, bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return res, err
+	}
+	req.Header.Add("developerToken", s.Auth.DeveloperToken)
+	req.Header.Add("clientCustomerId", s.Auth.CustomerId)
+	req.Header.Add("skipReportHeader", "true")
+	req.Header.Add("skipReportSummary", "true")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	return s.Client.Do(req)
+}
+
+func parseReport(report io.Reader) (collection []map[string]string, err error) {
+	reader := csv.NewReader(report)
+	header, err := reader.Read()
+	if err != nil {
+		return collection, err
+	}
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return collection, err
+		}
+		row := make(map[string]string)
+		for i := 0; i < len(record); i++ {
+			column := header[i]
+			row[column] = record[i]
+		}
+		collection = append(collection, row)
+	}
+	return collection, err
+}

--- a/v201705/shared_criterion.go
+++ b/v201705/shared_criterion.go
@@ -1,0 +1,9 @@
+package v201705
+
+type SharedCriterionService struct {
+	Auth
+}
+
+func NewSharedCriterionService(auth *Auth) *SharedCriterionService {
+	return &SharedCriterionService{Auth: *auth}
+}

--- a/v201705/shared_set.go
+++ b/v201705/shared_set.go
@@ -1,0 +1,9 @@
+package v201705
+
+type SharedSetService struct {
+	Auth
+}
+
+func NewSharedSetService(auth *Auth) *SharedSetService {
+	return &SharedSetService{Auth: *auth}
+}

--- a/v201705/targeting_idea.go
+++ b/v201705/targeting_idea.go
@@ -1,0 +1,311 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// TargetingIdeaService Use this service to generate new keyword ideas based on the parameters specified in the selector. See the TargetingIdeaSelector documentation for more details.
+// You can also use this service to retrieve statistics for existing keyword ideas by setting the selector's requestType to RequestType.STATS and passing in the appropriate search parameters.
+type TargetingIdeaService struct {
+	Auth
+}
+
+// NewTargetingIdeaService returns a new TargetingIdeaService
+func NewTargetingIdeaService(auth *Auth) *TargetingIdeaService {
+	return &TargetingIdeaService{Auth: *auth}
+}
+
+// TargetingIdeaSelector A descriptor for finding TargetingIdeas that match the specified criteria.
+// https://developers.google.com/adwords/api/docs/reference/v201705/TargetingIdeaService.TargetingIdeaSelector
+type TargetingIdeaSelector struct {
+	SearchParameters        []SearchParameter `xml:"searchParameters"`
+	IdeaType                string            `xml:"ideaType"`
+	RequestType             string            `xml:"requestType"`
+	RequestedAttributeTypes []string          `xml:"requestedAttributeTypes"`
+	Paging                  Paging            `xml:"paging"`
+	LocaleCode              string            `xml:"localeCode,omitempty"`
+	CurrencyCode            string            `xml:"currencyCode,omitempty"`
+}
+
+type SearchParameter interface{}
+
+type CategoryProductsAndServicesSearchParameter struct {
+	CategoryID int `xml:"categoryId"`
+}
+
+type CompetitionSearchParameter struct {
+	Levels []string `xml:"levels"`
+}
+
+type IdeaTextFilterSearchParameter struct {
+	Included []string `xml:"included"`
+	Excluded []string `xml:"excluded"`
+}
+
+type IncludeAdultContentSearchParameter struct{}
+
+type LanguageSearchParameter struct {
+	Languages []LanguageCriterion `xml:"languages"`
+}
+
+type LocationSearchParameter struct {
+	Locations []Location `xml:"locations"`
+}
+
+type NetworkSearchParameter struct {
+	NetworkSetting NetworkSetting `xml:"networkSetting"`
+}
+
+type RelatedToQuerySearchParameter struct {
+	Queries []string `xml:"queries"`
+}
+
+type RelatedToUrlSearchParameter struct {
+	Urls           []string `xml:"urls"`
+	IncludeSubUrls bool     `xml:"includeSubUrls"`
+}
+
+type SearchVolumeSearchParameter struct {
+	Minimum int `xml:"operation>minimum"`
+	Maximum int `xml:"operation>maximum"`
+}
+
+type SeedAdGroupIdSearchParameter struct {
+	AdGroupID int64 `xml:"adGroupId"`
+}
+
+type TargetingIdeas struct {
+	TargetingIdea []TargetingIdea `xml:"data"`
+}
+
+type TargetingIdea struct {
+	Key   string    `xml:"key"`
+	Value Attribute `xml:"value"`
+}
+
+type BooleanAttribute struct {
+	Value bool `xml:"value"`
+}
+
+type DoubleAttribute struct {
+	Value float64 `xml:"value"`
+}
+
+type IdeaTypeAttribute struct {
+	Value string `xml:"value"`
+}
+
+type IntegerSetAttribute struct {
+	Value []int `xml:"value"`
+}
+
+type LongAttribute struct {
+	Value int64 `xml:"value"`
+}
+
+type MoneyAttribute struct {
+	Value int64 `xml:"value>microAmount"`
+}
+
+type MonthlySearchVolumeAttribute struct {
+	Value []MonthlySearchVolume `xml:"value"`
+}
+
+type StringAttribute struct {
+	Value string `xml:"value"`
+}
+
+type WebpageDescriptorAttribute struct {
+	Value WebpageDescriptor `xml:"value"`
+}
+
+type WebpageDescriptor struct {
+	Url   string `xml:"url"`
+	Title string `xml:"title"`
+}
+
+type MonthlySearchVolume struct {
+	Year  int   `xml:"year"`
+	Month int   `xml:"month"`
+	Count int64 `xml:"count"`
+}
+
+type Attribute interface{}
+
+func (ti *TargetingIdea) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
+	for token, err := dec.Token(); err == nil; token, err = dec.Token() {
+		if err != nil {
+			return err
+		}
+		switch start := token.(type) {
+		case xml.StartElement:
+			tag := start.Name.Local
+			switch tag {
+			case "key":
+				var key string
+				err := dec.DecodeElement(&key, &start)
+				if err != nil {
+					return err
+				}
+				ti.Key = key
+			case "value":
+				value, err := attributeUnmarshalXML(dec, start)
+				// because there are multiple "value" elements we only want the ones that have an xsi attr
+				if err != nil {
+					break
+				}
+				ti.Value = value
+			}
+		}
+	}
+	return nil
+}
+
+func attributeUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (Attribute, error) {
+	attributeType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+	if err != nil {
+		return nil, err
+	}
+	switch attributeType {
+	case "BooleanAttribute":
+		ba := BooleanAttribute{}
+		err := dec.DecodeElement(&ba, &start)
+		return ba.Value, err
+	case "DoubleAttribute":
+		da := DoubleAttribute{}
+		err := dec.DecodeElement(&da, &start)
+		return da.Value, err
+	case "IdeaTypeAttribute":
+		ita := IdeaTypeAttribute{}
+		err := dec.DecodeElement(&ita, &start)
+		return ita.Value, err
+	case "IntegerSetAttribute":
+		isa := IntegerSetAttribute{}
+		err := dec.DecodeElement(&isa, &start)
+		return isa.Value, err
+	case "LongAttribute":
+		la := LongAttribute{}
+		err := dec.DecodeElement(&la, &start)
+		return la.Value, err
+	case "MoneyAttribute":
+		ma := MoneyAttribute{}
+		err := dec.DecodeElement(&ma, &start)
+		return ma.Value, err
+	case "MonthlySearchVolumeAttribute":
+		msva := MonthlySearchVolumeAttribute{}
+		err := dec.DecodeElement(&msva, &start)
+		return msva.Value, err
+	case "StringAttribute":
+		sa := StringAttribute{}
+		err := dec.DecodeElement(&sa, &start)
+		return sa.Value, err
+	case "WebpageDescriptorAttribute":
+		wda := WebpageDescriptorAttribute{}
+		err := dec.DecodeElement(&wda, &start)
+		return wda.Value, err
+	default:
+		return nil, fmt.Errorf("unknown attribute type %#v", attributeType)
+	}
+}
+
+func (tis TargetingIdeaSelector) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+
+	e.EncodeToken(start)
+
+	for _, searchParam := range tis.SearchParameters {
+		err := searchParameterMarshalXML(searchParam, e)
+		if err != nil {
+			return err
+		}
+	}
+
+	e.EncodeElement(&tis.IdeaType, xml.StartElement{Name: xml.Name{"", "ideaType"}})
+	e.EncodeElement(&tis.RequestType, xml.StartElement{Name: xml.Name{"", "requestType"}})
+	e.EncodeElement(&tis.RequestedAttributeTypes, xml.StartElement{Name: xml.Name{"", "requestedAttributeTypes"}})
+	e.EncodeElement(&tis.Paging, xml.StartElement{Name: xml.Name{"", "paging"}})
+
+	if tis.LocaleCode != "" {
+		e.EncodeElement(&tis.LocaleCode, xml.StartElement{Name: xml.Name{"", "localCode"}})
+	}
+
+	if tis.CurrencyCode != "" {
+		e.EncodeElement(&tis.CurrencyCode, xml.StartElement{Name: xml.Name{"", "currencyCode"}})
+	}
+
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func searchParameterMarshalXML(sp SearchParameter, e *xml.Encoder) error {
+	searchType := ""
+
+	switch t := sp.(type) {
+	case CategoryProductsAndServicesSearchParameter:
+		searchType = "CategoryProductsAndServicesSearchParameter"
+	case CompetitionSearchParameter:
+		searchType = "CompetitionSearchParameter"
+	case IdeaTextFilterSearchParameter:
+		searchType = "IdeaTextFilterSearchParameter"
+	case IncludeAdultContentSearchParameter:
+		searchType = "IncludeAdultContentSearchParameter"
+	case LanguageSearchParameter:
+		searchType = "LanguageSearchParameter"
+	case LocationSearchParameter:
+		searchType = "LocationSearchParameter"
+	case NetworkSearchParameter:
+		searchType = "NetworkSearchParameter"
+	case RelatedToQuerySearchParameter:
+		searchType = "RelatedToQuerySearchParameter"
+	case RelatedToUrlSearchParameter:
+		searchType = "RelatedToUrlSearchParameter"
+	case SearchVolumeSearchParameter:
+		searchType = "SearchVolumeSearchParameter"
+	case SeedAdGroupIdSearchParameter:
+		searchType = "SeedAdGroupIdSearchParameter"
+	default:
+		return fmt.Errorf("unknown search parameter type %#v\n", t)
+	}
+
+	// encode the inner element
+	e.EncodeElement(&sp, xml.StartElement{
+		xml.Name{"", "searchParameters"},
+		[]xml.Attr{
+			xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, searchType},
+		},
+	})
+
+	return nil
+}
+
+// Get Returns a page of ideas that match the query described by the specified TargetingIdeaSelector.
+// https://developers.google.com/adwords/api/docs/reference/v201705/TargetingIdeaService
+func (s *TargetingIdeaService) Get(selector TargetingIdeaSelector) (targetingIdeas []TargetingIdeas, totalCount int64, err error) {
+
+	respBody, err := s.Auth.request(
+		targetingIdeaServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     TargetingIdeaSelector `xml:"selector"`
+		}{
+			XMLName: xml.Name{
+				Space: baseTrafficUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+	if err != nil {
+		return targetingIdeas, totalCount, err
+	}
+	getResp := struct {
+		Size           int64            `xml:"rval>totalNumEntries"`
+		TargetingIdeas []TargetingIdeas `xml:"rval>entries"`
+	}{}
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return targetingIdeas, totalCount, err
+	}
+	return getResp.TargetingIdeas, getResp.Size, err
+}

--- a/v201705/traffic_estimator.go
+++ b/v201705/traffic_estimator.go
@@ -1,0 +1,143 @@
+package v201705
+
+import "encoding/xml"
+
+type TrafficEstimatorService struct {
+	Auth
+}
+
+func NewTrafficEstimatorService(auth *Auth) *TrafficEstimatorService {
+	return &TrafficEstimatorService{Auth: *auth}
+}
+
+type KeywordEstimateRequest struct {
+	Keyword KeywordCriterion `xml:"keyword"`
+}
+
+type AdGroupEstimateRequest struct {
+	KeywordEstimateRequests []KeywordEstimateRequest `xml:"keywordEstimateRequests"`
+	MaxCpc                  int64                    `xml:"https://adwords.google.com/api/adwords/cm/v201705 maxCpc>microAmount"`
+}
+
+type CampaignEstimateRequest struct {
+	AdGroupEstimateRequests []AdGroupEstimateRequest `xml:"adGroupEstimateRequests"`
+}
+
+type TrafficEstimatorSelector struct {
+	CampaignEstimateRequests []CampaignEstimateRequest `xml:"campaignEstimateRequests"`
+}
+
+type StatsEstimate struct {
+	AverageCpc        int64   `xml:"averageCpc>microAmount"`
+	AveragePosition   float64 `xml:"averagePosition"`
+	ClickThroughRate  float64 `xml:"clickThroughRate"`
+	ClicksPerDay      float64 `xml:"clicksPerDay"`
+	ImpressionsPerDay float64 `xml:"impressionsPerDay"`
+	TotalCost         int64   `xml:"totalCost>microAmount"`
+}
+
+type KeywordEstimate struct {
+	Min StatsEstimate `xml:"min"`
+	Max StatsEstimate `xml:"max"`
+}
+
+type AdGroupEstimate struct {
+	KeywordEstimates []KeywordEstimate `xml:"keywordEstimates"`
+}
+
+type CampaignEstimate struct {
+	AdGroupEstimates []AdGroupEstimate `xml:"adGroupEstimates"`
+}
+
+// Get returns an array of CampaignEstimates, holding AdGroupEstimates which
+// hold KeywordEstimates, which hold the minimum and maximum values based on
+// the requested keywords.
+//
+// Example
+//
+//	keywordEstimateRequests := []KeywordEstimateRequest{
+//		KeywordEstimateRequest{
+//			KeywordCriterion{
+//				Text:      "mars cruise",
+//				MatchType: "BROAD",
+//			},
+//		},
+//		KeywordEstimateRequest{
+//			KeywordCriterion{
+//				Text:      "cheap cruise",
+//				MatchType: "EXACT",
+//			},
+//		},
+//		KeywordEstimateRequest{
+//			KeywordCriterion{
+//				Text:      "cruise",
+//				MatchType: "EXACT",
+//			},
+//		},
+//	}
+//
+//	adGroupEstimateRequests := []AdGroupEstimateRequest{
+//		AdGroupEstimateRequest{
+//			KeywordEstimateRequests: keywordEstimateRequests,
+//			MaxCpc:                  1000000,
+//		},
+//	}
+//
+//	campaignEstimateRequests := []CampaignEstimateRequest{
+//		CampaignEstimateRequest{
+//			AdGroupEstimateRequests: adGroupEstimateRequests,
+//		},
+//	}
+//
+//	estimates, err := trafficEstimatorService.Get(TrafficEstimatorSelector{
+//		CampaignEstimateRequests: campaignEstimateRequests,
+//	})
+//
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	for _, estimate := range estimates {
+//		for _, adGroupEstimate := range estimate.AdGroupEstimates {
+//			for _, keywordEstimate := range adGroupEstimate.KeywordEstimates {
+//				fmt.Printf("Avg cpc: %d", keywordEstimate.Min.AverageCpc)
+//			}
+//		}
+//	}
+//
+// Relevant documentation
+//
+// 		https://developers.google.com/adwords/api/docs/reference/v201705/TrafficEstimatorService#get
+//
+func (s *TrafficEstimatorService) Get(selector TrafficEstimatorSelector) (res []CampaignEstimate, err error) {
+
+	respBody, err := s.Auth.request(
+		trafficEstimatorServiceUrl,
+		"get",
+		struct {
+			XMLName xml.Name
+			Sel     TrafficEstimatorSelector `xml:"selector"`
+		}{
+			XMLName: xml.Name{
+				Space: baseTrafficUrl,
+				Local: "get",
+			},
+			Sel: selector,
+		},
+	)
+
+	if err != nil {
+		return res, err
+	}
+
+	getResp := struct {
+		CampaignEstimates []CampaignEstimate `xml:"rval>campaignEstimates"`
+	}{}
+
+	err = xml.Unmarshal([]byte(respBody), &getResp)
+	if err != nil {
+		return res, err
+	}
+
+	return getResp.CampaignEstimates, err
+}

--- a/v201705/trial.go
+++ b/v201705/trial.go
@@ -1,0 +1,9 @@
+package v201705
+
+type TrialService struct {
+	Auth
+}
+
+func NewTrialService(auth *Auth) *TrialService {
+	return &TrialService{Auth: *auth}
+}

--- a/v201705/xml.go
+++ b/v201705/xml.go
@@ -1,0 +1,16 @@
+package v201705
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+func findAttr(as []xml.Attr, name xml.Name) (value string, err error) {
+	for _, a := range as {
+		an := a.Name
+		if an.Space == name.Space && an.Local == name.Local {
+			return a.Value, nil
+		}
+	}
+	return "", fmt.Errorf("attribute %#v not found", name)
+}


### PR DESCRIPTION
I basically copied over v201609, find/replaced v201609 to v201702, and looked through the [migration guide](https://developers.google.com/adwords/api/docs/guides/migration/v201702) to see what needs to be changed. There still needs some work to be done to get tests working. Currently when I run `go test` inside the `v201702` directory I get the following output:

```
# github.com/Getsidecar/gads/v201702
./base_test.go:30: undefined: NewCredentials
./basic_operation_test.go:11: undefined: NewCredentials
./basic_operation_test.go:54: undefined: NewCredentials
./basic_operation_test.go:149: undefined: NewCredentials
./basic_operation_test.go:194: undefined: NewCredentials
./basic_operation_test.go:294: undefined: NewCredentials
./basic_operation_test.go:341: undefined: NewCredentials
./basic_operation_test.go:432: undefined: NewCredentials
./basic_operation_test.go:481: undefined: NewCredentials
./misc_test.go:21: undefined: NewCredentials
./misc_test.go:21: too many errors
FAIL	github.com/Getsidecar/gads/v201702 [build failed]
```

Does anyone have insights into how to fix this? Or in general did I go about adding the v201702 API to this library the correct way?