### PR TITLE
Return error form adwords instead of empty error message in adwords unmarshall fault

### DIFF
--- a/v201710/base.go
+++ b/v201710/base.go
@@ -3,6 +3,7 @@ package v201710
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -291,6 +292,10 @@ func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}) (
 					origErr: &fault.Errors,
 				}
 			}
+		}
+
+		if fault.Errors.ApiExceptionFaults == nil {
+			return soapResp.Body.Response, errors.New(fault.FaultString)
 		}
 
 		return soapResp.Body.Response, &fault.Errors

--- a/v201710/sandbox_test.go
+++ b/v201710/sandbox_test.go
@@ -957,10 +957,6 @@ func Testrequest(t *testing.T) {
 		},
 	)
 
-	if err != nil && err.Error() == "" {
-		t.Fatal(err.Error())
-	}
-
 	defer func() {
 		adGroups[0].Status = "REMOVED"
 		_, err = NewAdGroupService(&config.Auth).Mutate(AdGroupOperations{"SET": adGroups})
@@ -969,4 +965,7 @@ func Testrequest(t *testing.T) {
 		}
 	}()
 
+	if err != nil && err.Error() == "" {
+		t.Fatal(err.Error())
+	}
 }

--- a/v201710/sandbox_test.go
+++ b/v201710/sandbox_test.go
@@ -933,3 +933,40 @@ func TestRateError(t *testing.T) {
 	wg.Wait()
 
 }
+
+func Testrequest(t *testing.T) {
+	config := getTestConfig()
+	campaigns, _, err := NewCampaignService(&config.Auth).Get(Selector{
+		Fields: []string{"Id", "Name", "CampaignId"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	campaignId := campaigns[0].Id
+	adGroups, err := NewAdGroupService(&config.Auth).Mutate(
+		AdGroupOperations{
+			"ADD": {
+				AdGroup{
+					Name:       "test ad group " + rand_str(10),
+					Status:     "PAUSED",
+					CampaignId: campaignId,
+				},
+			},
+		},
+	)
+
+	if err != nil && err.Error() == "" {
+		t.Fatal(err.Error())
+	}
+
+	defer func() {
+		adGroups[0].Status = "REMOVED"
+		_, err = NewAdGroupService(&config.Auth).Mutate(AdGroupOperations{"SET": adGroups})
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+}

--- a/v201710/sandbox_test.go
+++ b/v201710/sandbox_test.go
@@ -953,7 +953,11 @@ func TestSandboxEmptyErrorMessage(t *testing.T) {
 
 	_, _, err := NewCampaignService(auth).Get(Selector{})
 
+	if err == nil {
+		t.Fatal("Test is not giving an error")
+	}
+
 	if err != nil && err.Error() == "" {
-		t.Fatal()
+		t.Fatal("Test giving a blank error message")
 	}
 }

--- a/v201710/sandbox_test.go
+++ b/v201710/sandbox_test.go
@@ -941,7 +941,7 @@ type StringClient string
 func (s StringClient) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Body:       BufferCloser{bytes.NewBufferString(string(s))},
-		StatusCode: 500,
+		StatusCode: http.StatusInternalServerError,
 	}, nil
 }
 

--- a/v201710/sandbox_test.go
+++ b/v201710/sandbox_test.go
@@ -934,7 +934,7 @@ func TestRateError(t *testing.T) {
 
 }
 
-func Testrequest(t *testing.T) {
+func TestSandboxEmptyErrorMessage(t *testing.T) {
 	config := getTestConfig()
 	campaigns, _, err := NewCampaignService(&config.Auth).Get(Selector{
 		Fields: []string{"Id", "Name", "CampaignId"},
@@ -945,25 +945,17 @@ func Testrequest(t *testing.T) {
 	}
 
 	campaignId := campaigns[0].Id
-	adGroups, err := NewAdGroupService(&config.Auth).Mutate(
+	_, err = NewAdGroupService(&config.Auth).Mutate(
 		AdGroupOperations{
 			"ADD": {
 				AdGroup{
-					Name:       "test ad group " + rand_str(10),
+					Name:       "test ad group" + rand_str(10),
 					Status:     "PAUSED",
 					CampaignId: campaignId,
 				},
 			},
 		},
 	)
-
-	defer func() {
-		adGroups[0].Status = "REMOVED"
-		_, err = NewAdGroupService(&config.Auth).Mutate(AdGroupOperations{"SET": adGroups})
-		if err != nil {
-			t.Error(err)
-		}
-	}()
 
 	if err != nil && err.Error() == "" {
 		t.Fatal(err.Error())


### PR DESCRIPTION
This PR is part of JIRA PS-381: gads is returning blank for an error message when trying to mutate operations.
The modification is an additional 'if' statement in base.go

-Notes:
-I have added a test case in sandbox_test.go to replicate the error and fail the test case if error message is blank.
-I ran all the sandbox test cases again and they pass.
