### PR TITLE
Updating Adgroup properties

### DIFF
--- a/v201710/ad_group.go
+++ b/v201710/ad_group.go
@@ -30,13 +30,14 @@ type AdGroup struct {
 	CampaignId                   int64                          `xml:"campaignId,omitempty"`
 	CampaignName                 string                         `xml:"campaignName,omitempty"`
 	Name                         string                         `xml:"name,omitempty"`
-	AdServingOptimizationStatus  string                         `xml:"adServingOptimizationStatus"`
 	Status                       string                         `xml:"status,omitempty"`
 	Settings                     []AdSetting                    `xml:"settings,omitempty"`
+	Labels                       []Label                        `xml:"labels"`
 	BiddingStrategyConfiguration []BiddingStrategyConfiguration `xml:"biddingStrategyConfiguration"`
 	ContentBidCriterionTypeGroup *string                        `xml:"contentBidCriterionTypeGroup"`
 	UrlCustomParameters          *CustomParameters              `xml:"urlCustomParameters"`
-	Labels                       []Label                        `xml:"labels"`
+	Type                         string                         `xml:"adGroupType"`
+	RotationMode                 string                         `xml:"adGroupAdRotationMode>adRotationMode"`
 }
 
 type AdGroupOperations map[string][]AdGroup


### PR DESCRIPTION
In this PR I'm updating the properties of a `AdGroup` to match [the Adwords API documentation](https://developers.google.com/adwords/api/docs/reference/v201710/AdGroupService.AdGroup). I also added a sandbox test to confirm that it works.