### PR TITLE
Fixing batch text ad operation and adding test for all batch job operations

### DIFF
--- a/v201710/ad_group_ad.go
+++ b/v201710/ad_group_ad.go
@@ -1,8 +1,6 @@
 package v201710
 
-import (
-	"encoding/xml"
-)
+import "encoding/xml"
 
 type AdGroupAdService struct {
 	Auth
@@ -50,6 +48,63 @@ type ExpandedTextAd struct {
 	Labels              []Label                `xml:"-"`
 	BaseCampaignId      *int64                 `xml:"-"`
 	BaseAdGroupId       *int64                 `xml:"-"`
+}
+
+type BatchExpandedTextAd struct {
+	AdGroupId           int64                  `xml:"-"`
+	Id                  int64                  `xml:"id,omitempty"`
+	FinalUrls           []string               `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string               `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate string                 `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters      `xml:"urlCustomParameters,omitempty"`
+	Type                string                 `xml:"type,omitempty"`
+	HeadlinePart1       string                 `xml:"headlinePart1,omitempty"`
+	HeadlinePart2       string                 `xml:"headlinePart2,omitempty"`
+	Description         string                 `xml:"description,omitempty"`
+	Path1               string                 `xml:"path1,omitempty"`
+	Path2               string                 `xml:"path2,omitempty"`
+	ExperimentData      *AdGroupExperimentData `xml:"-"`
+	Status              string                 `xml:"-"`
+	Labels              []Label                `xml:"-"`
+	BaseCampaignId      *int64                 `xml:"-"`
+	BaseAdGroupId       *int64                 `xml:"-"`
+}
+
+type BatchExpandedTextAdInner struct {
+	HeadlinePart1       string   `xml:"headlinePart1,omitempty"`
+	HeadlinePart2       string   `xml:"headlinePart2,omitempty"`
+	Description         string   `xml:"description,omitempty"`
+	Path1               string   `xml:"path1,omitempty"`
+	Path2               string   `xml:"path2,omitempty"`
+	FinalUrls           []string `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string `xml:"FinalMobileUrls,omitempty"`
+	TrackingUrlTemplate string   `xml:"trackingUrlTemplate,omitempty"`
+}
+
+func (ad BatchExpandedTextAd) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Attr = []xml.Attr{xml.Attr{Value: "operand"}}
+	e.EncodeToken(start)
+
+	e.EncodeElement(ad.Id, xml.StartElement{Name: xml.Name{"", "id"}})
+	e.EncodeElement(ad.AdGroupId, xml.StartElement{Name: xml.Name{"", "adGroupId"}})
+	e.EncodeElement(BatchExpandedTextAdInner{
+		HeadlinePart1:       ad.HeadlinePart1,
+		HeadlinePart2:       ad.HeadlinePart2,
+		Description:         ad.Description,
+		Path1:               ad.Path1,
+		Path2:               ad.Path2,
+		FinalUrls:           ad.FinalUrls,
+		TrackingUrlTemplate: ad.TrackingUrlTemplate,
+	}, xml.StartElement{
+		xml.Name{"", "ad"},
+		[]xml.Attr{
+			xml.Attr{xml.Name{"http://www.w3.org/2001/XMLSchema-instance", "type"}, "ExpandedTextAd"},
+		},
+	})
+	e.EncodeElement(ad.Status, xml.StartElement{Name: xml.Name{"", "status"}})
+	e.EncodeElement(ad.Labels, xml.StartElement{Name: xml.Name{"", "labels"}})
+
+	return e.EncodeToken(xml.EndElement{Name: start.Name})
 }
 
 type ResponsiveDisplayAd struct {


### PR DESCRIPTION
## Description

The Paid Search project needs to be able to send operations for keywords, negative keywords, campaigns, adgroups and text ads using the Adwords' [BatchJob](https://developers.google.com/adwords/api/docs/reference/v201710/BatchJobService) functionality. Please read [this design doc](https://getsidecar.atlassian.net/wiki/spaces/PDMPM/pages/582549505/DESIGN+DOC+Paid+Search+Batch+Updates+Improvement) for full context.

In [my POC](https://gist.github.com/davewalk/e788cfb340ec04c772ca288a295ee0e3) everything worked correctly without making any code changes _except_ for text ad operations. After debugging, I discovered that the issue was this project wasn't marshaling the XML properly like it is in the [AdGroupAd service](https://github.com/Getsidecar/gads/blob/master/v201710/ad_group_ad.go#L291).

My fix for this was to add a new `BatchExpandedTextAd` struct that would be used when sending text ads in a BatchJob so that I could control the XML encoding. It isn't a very elegant solution, but I wanted to avoid changing the guts of the XML marshaling if I could and while this is pretty blunt, it works.

I've added a sandbox test to confirm that all of the operations we require work now. The test deletes the newly created campaign when done so that it is idempotent.

