### PR TITLE
remove unused logging in XML unmarshal

### DIFF
--- a/v201710/ad_group_ads.go
+++ b/v201710/ad_group_ads.go
@@ -84,7 +84,6 @@ func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 				if err != nil {
 					return err
 				}
-				fmt.Println(typeName)
 				switch typeName {
 				case "TextAd":
 					a := TextAd{AdGroupId: adGroupId}


### PR DESCRIPTION
## Description

**Please keep in mind that this is a public repo**  

Removing a line that logs the type of each item when un-marshaling from XML. It just adds a lot of noise to the unit test output of some other repos.

## Checklist
* [x] Any important design changes are documented in project's Markdown documentation
